### PR TITLE
25: Correctly set filenames on ODIN to avoid doubly setting them

### DIFF
--- a/src/artemis/devices/eiger.py
+++ b/src/artemis/devices/eiger.py
@@ -123,8 +123,7 @@ class EigerDetector(Device):
         self.odin.fan.forward_stream.put(True)
         self.odin.file_writer.id.put(self.detector_params.acquisition_id)
         self.odin.file_writer.file_path.put(self.detector_params.directory)
-        self.odin.file_writer.file_name.put(self.detector_params.prefix)
-        self.odin.meta.file_name.put(self.detector_params.prefix)
+        self.odin.file_writer.file_prefix.put(self.detector_params.prefix)
 
     def set_mx_settings_pvs(self):
         beam_x_pixels, beam_y_pixels = self.get_beam_position_pixels(

--- a/src/artemis/devices/eiger_odin.py
+++ b/src/artemis/devices/eiger_odin.py
@@ -19,7 +19,6 @@ class EigerFan(Device):
 
 
 class OdinMetaListener(Device):
-    file_name: EpicsSignalWithRBV = Component(EpicsSignalWithRBV, "FileName")
     initialised: EpicsSignalRO = Component(EpicsSignalRO, "ProcessConnected_RBV")
 
 
@@ -28,6 +27,7 @@ class OdinFileWriter(HDF5Plugin_V22):
     id: EpicsSignalWithRBV = Component(EpicsSignalWithRBV, "AcquisitionID")
     image_height: EpicsSignalWithRBV = Component(EpicsSignalWithRBV, "ImageHeight")
     image_width: EpicsSignalWithRBV = Component(EpicsSignalWithRBV, "ImageWidth")
+    file_prefix: EpicsSignal = Component(EpicsSignalWithRBV, "FP:FileName")
 
 
 class OdinNode(Device):

--- a/src/artemis/devices/system_tests/test_eiger_system.py
+++ b/src/artemis/devices/system_tests/test_eiger_system.py
@@ -7,6 +7,7 @@ from src.artemis.devices.det_dist_to_beam_converter import (
 import pytest
 import os
 from epics import caput
+import numpy as np
 
 
 @pytest.fixture()
@@ -34,7 +35,18 @@ def eiger():
 
 @pytest.mark.s03
 def test_can_stage_and_unstage_eiger(eiger: EigerDetector):
+    times_id_has_changed = 0
+
+    def file_writer_id_monitor(*_, **kwargs):
+        nonlocal times_id_has_changed
+        if not np.array_equal(kwargs["old_value"], kwargs["value"]):
+            times_id_has_changed += 1
+
+    eiger.odin.file_writer.id.subscribe(file_writer_id_monitor)
     eiger.stage()
+    assert (
+        times_id_has_changed == 2
+    )  # Once for initial connection and once for changing the value
     assert eiger.cam.acquire.get() == 1
     # S03 filewriters stay in error
     eiger.odin.check_odin_initialised = lambda: (True, "")


### PR DESCRIPTION
Fixes #25 

To test:
* Set up a monitor on Acquisition ID: `camonitor -S BL03S-EA-EIGER-01:OD:AcquisitionID`
* Run the Eiger system tests
* Confirm Acquisition ID gets set to the correct value and only once. e.g. not the behavior in https://github.com/DiamondLightSource/python-artemis/pull/23#issuecomment-1029060653