### PR TITLE
34: Remove check on number of images in grid scan status

### DIFF
--- a/src/artemis/devices/eiger.py
+++ b/src/artemis/devices/eiger.py
@@ -25,20 +25,28 @@ class EigerDetector(Device):
     stale_params: EpicsSignalRO = Component(EpicsSignalRO, "CAM:StaleParameters_RBV")
     bit_depth: EpicsSignalRO = Component(EpicsSignalRO, "CAM:BitDepthImage_RBV")
 
-    detector_params: DetectorParams
-
     STALE_PARAMS_TIMEOUT = 60
 
-    def __init__(self, name="Eiger Detector", *args, **kwargs):
+    def __init__(
+        self, detector_params: DetectorParams, name="Eiger Detector", *args, **kwargs
+    ):
         super().__init__(name=name, *args, **kwargs)
+        self.detector_params = detector_params
+        self.check_detector_variables_set()
 
     def check_detector_variables_set(self):
         if self.detector_params is None:
             raise Exception("Parameters for scan must be specified")
 
         to_check = [
-            (self.detector_params.detector_size_constants is None, "Detector Size must be set"),
-            (self.detector_params.beam_xy_converter is None, "Beam converter must be set"),
+            (
+                self.detector_params.detector_size_constants is None,
+                "Detector Size must be set",
+            ),
+            (
+                self.detector_params.beam_xy_converter is None,
+                "Beam converter must be set",
+            ),
         ]
 
         errors = [message for check_result, message in to_check if check_result]
@@ -47,7 +55,6 @@ class EigerDetector(Device):
             raise Exception("\n".join(errors))
 
     def stage(self):
-        self.check_detector_variables_set()
         self.odin.nodes.clear_odin_errors()
         status_ok, error_message = self.odin.check_odin_initialised()
         if not status_ok:

--- a/src/artemis/devices/eiger.py
+++ b/src/artemis/devices/eiger.py
@@ -27,9 +27,7 @@ class EigerDetector(Device):
 
     STALE_PARAMS_TIMEOUT = 60
 
-    def __init__(
-        self, detector_params: DetectorParams, name="Eiger Detector", *args, **kwargs
-    ):
+    def __init__(self, detector_params: DetectorParams, name="Eiger Detector", *args, **kwargs):
         super().__init__(name=name, *args, **kwargs)
         self.detector_params = detector_params
         self.check_detector_variables_set()

--- a/src/artemis/devices/fast_grid_scan.py
+++ b/src/artemis/devices/fast_grid_scan.py
@@ -13,7 +13,6 @@ from ophyd.status import DeviceStatus, StatusBase
 from ophyd.utils.epics_pvs import set_and_wait
 
 from dataclasses import dataclass
-from typing import Any
 
 from src.artemis.devices.motors import (
     GridScanLimit,
@@ -59,9 +58,7 @@ class GridScanParams:
         )
 
 
-def scan_in_limits(
-    limit: GridScanLimit, start: float, steps: float, step_size: float
-) -> bool:
+def scan_in_limits(limit: GridScanLimit, start: float, steps: float, step_size: float) -> bool:
     end = start + (steps * step_size)
     return limit.is_within(start) and limit.is_within(end)
 
@@ -144,9 +141,7 @@ class FastGridScan(Device):
     y1_start: EpicsSignalWithRBV = Component(EpicsSignalWithRBV, "Y_START")
     z1_start: EpicsSignalWithRBV = Component(EpicsSignalWithRBV, "Z_START")
 
-    position_counter: EpicsSignal = Component(
-        EpicsSignal, "POS_COUNTER", write_pv="POS_COUNTER_WRITE"
-    )
+    position_counter: EpicsSignal = Component(EpicsSignal, "POS_COUNTER", write_pv="POS_COUNTER_WRITE")
     x_counter: EpicsSignalRO = Component(EpicsSignalRO, "X_COUNTER")
     y_counter: EpicsSignalRO = Component(EpicsSignalRO, "Y_COUNTER")
     scan_invalid: EpicsSignalRO = Component(EpicsSignalRO, "SCAN_INVALID")

--- a/src/artemis/devices/fast_grid_scan.py
+++ b/src/artemis/devices/fast_grid_scan.py
@@ -90,6 +90,7 @@ class GridScanCompleteStatus(DeviceStatus):
             fraction = None
             time_remaining = None
             self.set_exception(e)
+            self.clean_up()
         else:
             time_remaining = time_elapsed / fraction
         for watcher in self._watchers:

--- a/src/artemis/devices/unit_tests/test_eiger.py
+++ b/src/artemis/devices/unit_tests/test_eiger.py
@@ -2,7 +2,7 @@ import pytest
 from mockito import mock, when, verify, ANY
 
 from ophyd.sim import make_fake_device
-from src.artemis.devices.eiger import EigerDetector, DetectorParams
+from src.artemis.devices.eiger import EigerDetector
 from src.artemis.devices.det_dim_constants import DetectorSizeConstants, DetectorSize
 
 
@@ -13,27 +13,22 @@ TEST_EIGER_DIMENSION = DetectorSize(TEST_EIGER_DIMENSION_X, TEST_EIGER_DIMENSION
 TEST_PIXELS_X_EIGER = 2068
 TEST_PIXELS_Y_EIGER = 2162
 TEST_PIXELS_EIGER = DetectorSize(TEST_PIXELS_X_EIGER, TEST_PIXELS_Y_EIGER)
-TEST_DETECTOR_SIZE_CONSTANTS = DetectorSizeConstants(TEST_EIGER_STRING, TEST_EIGER_DIMENSION, TEST_PIXELS_EIGER,
-                                                     TEST_EIGER_DIMENSION, TEST_PIXELS_EIGER)
+TEST_DETECTOR_SIZE_CONSTANTS = DetectorSizeConstants(
+    TEST_EIGER_STRING, TEST_EIGER_DIMENSION, TEST_PIXELS_EIGER, TEST_EIGER_DIMENSION, TEST_PIXELS_EIGER
+)
 
 
 @pytest.fixture
 def fake_eiger():
     FakeEigerDetector = make_fake_device(EigerDetector)
-    fake_eiger: EigerDetector = FakeEigerDetector(name='test')
+    fake_eiger: EigerDetector = FakeEigerDetector(detector_params=mock(), name="test")
 
     return fake_eiger
 
 
 @pytest.mark.parametrize(
     "current_energy, request_energy, is_energy_change",
-    [
-        (100.0, 100.0, False),
-        (100.0, 200.0, True),
-        (100.0, 50.0, True),
-        (100.0, 100.09, False),
-        (100.0, 99.91, False)
-    ]
+    [(100.0, 100.0, False), (100.0, 200.0, True), (100.0, 50.0, True), (100.0, 100.09, False), (100.0, 99.91, False)],
 )
 def test_detector_threshold(fake_eiger, current_energy: float, request_energy: float, is_energy_change: bool):
 
@@ -56,10 +51,12 @@ def test_detector_threshold(fake_eiger, current_energy: float, request_energy: f
         (mock(), None, mock(), 1),
         (None, None, mock(), 1),
         (None, None, None, 1),
-        (mock(), None, None, 2)
-    ]
+        (mock(), None, None, 2),
+    ],
 )
-def test_check_detector_variables(fake_eiger, detector_params, detector_size_constants, beam_xy_converter, expected_error_number):
+def test_check_detector_variables(
+    fake_eiger, detector_params, detector_size_constants, beam_xy_converter, expected_error_number
+):
     fake_eiger.detector_params = detector_params
 
     if detector_params is not None:
@@ -69,7 +66,7 @@ def test_check_detector_variables(fake_eiger, detector_params, detector_size_con
     if expected_error_number != 0:
         with pytest.raises(Exception) as e:
             fake_eiger.check_detector_variables_set()
-        number_of_errors = str(e.value).count('\n') + 1
+        number_of_errors = str(e.value).count("\n") + 1
 
         assert number_of_errors == expected_error_number
     else:

--- a/src/artemis/devices/unit_tests/test_gridscan.py
+++ b/src/artemis/devices/unit_tests/test_gridscan.py
@@ -1,18 +1,17 @@
+import pytest
+from bluesky.run_engine import RunEngine
+from mockito import mock, verify, when
+from mockito.matchers import ANY, ARGS, KWARGS
 from ophyd.epics_motor import EpicsMotor
 from ophyd.sim import make_fake_device
 from src.artemis.devices.fast_grid_scan import (
     FastGridScan,
     GridScanParams,
+    scan_in_limits,
     set_fast_grid_scan_params,
     time,
-    scan_in_limits,
 )
 from src.artemis.devices.motors import GridScanMotorBundle
-
-from mockito import when, mock, verify
-from mockito.matchers import ANY, ARGS, KWARGS
-import pytest
-from bluesky.run_engine import RunEngine
 
 
 @pytest.fixture
@@ -63,7 +62,7 @@ def test_given_settings_valid_when_kickoff_then_run_started(
     status.wait()
 
     verify(fast_grid_scan.run_cmd).set(1)
-    assert status.exception() == None
+    assert status.exception() is None
 
 
 def run_test_on_complete_watcher(
@@ -84,7 +83,7 @@ def run_test_on_complete_watcher(
     verify(watcher).__call__(
         *ARGS,
         current=put_value,
-        target=num_pos_1d ** 2,
+        target=num_pos_1d**2,
         fraction=expected_frac,
         **KWARGS,
     )
@@ -108,30 +107,6 @@ def test_given_invalid_image_number_then_complete_watcher_correct(
     assert complete_status.exception()
 
 
-def test_running_finished_with_not_all_images_done_then_complete_status_in_error(
-    fast_grid_scan: FastGridScan,
-):
-    num_pos_1d = 2
-    RE = RunEngine()
-    RE(
-        set_fast_grid_scan_params(
-            fast_grid_scan, GridScanParams(num_pos_1d, num_pos_1d)
-        )
-    )
-
-    fast_grid_scan.status.sim_put(1)
-
-    complete_status = fast_grid_scan.complete()
-    assert not complete_status.done
-    fast_grid_scan.status.sim_put(0)
-
-    with pytest.raises(Exception):
-        complete_status.wait()
-
-    assert complete_status.done
-    assert complete_status.exception() != None
-
-
 def test_running_finished_with_all_images_done_then_complete_status_finishes_not_in_error(
     fast_grid_scan: FastGridScan,
 ):
@@ -147,13 +122,13 @@ def test_running_finished_with_all_images_done_then_complete_status_finishes_not
 
     complete_status = fast_grid_scan.complete()
     assert not complete_status.done
-    fast_grid_scan.position_counter.sim_put(num_pos_1d ** 2)
+    fast_grid_scan.position_counter.sim_put(num_pos_1d**2)
     fast_grid_scan.status.sim_put(0)
 
     complete_status.wait()
 
     assert complete_status.done
-    assert complete_status.exception() == None
+    assert complete_status.exception() is None
 
 
 def create_motor_bundle_with_x_limits(low_limit, high_limit) -> GridScanMotorBundle:

--- a/src/artemis/fast_grid_scan_plan.py
+++ b/src/artemis/fast_grid_scan_plan.py
@@ -63,7 +63,7 @@ class FullParameters:
         omega_start=0.0,
         omega_increment=0.1,
         num_images=10,
-        use_roi_mode = False,
+        use_roi_mode=False,
     )
     ispyb_params: IspybParams = IspybParams(
         sample_id=None,
@@ -98,11 +98,6 @@ def run_gridscan(
     # TODO: Check topup gate
     yield from set_fast_grid_scan_params(fgs, parameters.grid_scan_params)
 
-    eiger.detector_size_constants = parameters.detector
-    eiger.use_roi_mode = parameters.use_roi
-    eiger.detector_params = parameters.detector_params
-    eiger.beam_xy_converter = parameters.det_to_distance
-
     @bpp.stage_decorator([zebra, eiger, fgs])
     def do_fgs():
         yield from bps.kickoff(fgs)
@@ -123,7 +118,11 @@ def get_plan(parameters: FullParameters):
     fast_grid_scan = FastGridScan(
         name="fgs", prefix=f"{parameters.beamline}-MO-SGON-01:FGS:"
     )
-    eiger = EigerDetector(name="eiger", prefix=f"{parameters.beamline}-EA-EIGER-01:")
+    eiger = EigerDetector(
+        parameters.detector_params,
+        name="eiger",
+        prefix=f"{parameters.beamline}-EA-EIGER-01:",
+    )
     zebra = Zebra(name="zebra", prefix=f"{parameters.beamline}-EA-ZEBRA-01:")
 
     return run_gridscan(fast_grid_scan, zebra, eiger, parameters)

--- a/src/artemis/tests/test_fast_grid_scan_plan.py
+++ b/src/artemis/tests/test_fast_grid_scan_plan.py
@@ -1,14 +1,25 @@
-from src.artemis.fast_grid_scan_plan import FullParameters
+from src.artemis.fast_grid_scan_plan import FullParameters, get_plan
 from src.artemis.devices.det_dim_constants import (
     EIGER_TYPE_EIGER2_X_16M,
     EIGER_TYPE_EIGER2_X_4M,
     EIGER2_X_4M_DIMENSION,
 )
+import types
 
 
 def test_given_full_parameters_dict_when_detector_name_used_and_converted_then_detector_constants_correct():
     params = FullParameters().to_dict()
-    assert params["detector_params"]["detector_size_constants"] == EIGER_TYPE_EIGER2_X_16M
+    assert (
+        params["detector_params"]["detector_size_constants"] == EIGER_TYPE_EIGER2_X_16M
+    )
     params["detector_params"]["detector_size_constants"] = EIGER_TYPE_EIGER2_X_4M
     params: FullParameters = FullParameters.from_dict(params)
-    assert params.detector_params.detector_size_constants.det_dimension == EIGER2_X_4M_DIMENSION
+    assert (
+        params.detector_params.detector_size_constants.det_dimension
+        == EIGER2_X_4M_DIMENSION
+    )
+
+
+def test_when_get_plan_called_then_generator_returned():
+    plan = get_plan(FullParameters())
+    assert isinstance(plan, types.GeneratorType)

--- a/src/artemis/tests/test_fast_grid_scan_plan.py
+++ b/src/artemis/tests/test_fast_grid_scan_plan.py
@@ -9,15 +9,10 @@ import types
 
 def test_given_full_parameters_dict_when_detector_name_used_and_converted_then_detector_constants_correct():
     params = FullParameters().to_dict()
-    assert (
-        params["detector_params"]["detector_size_constants"] == EIGER_TYPE_EIGER2_X_16M
-    )
+    assert params["detector_params"]["detector_size_constants"] == EIGER_TYPE_EIGER2_X_16M
     params["detector_params"]["detector_size_constants"] = EIGER_TYPE_EIGER2_X_4M
     params: FullParameters = FullParameters.from_dict(params)
-    assert (
-        params.detector_params.detector_size_constants.det_dimension
-        == EIGER2_X_4M_DIMENSION
-    )
+    assert params.detector_params.detector_size_constants.det_dimension == EIGER2_X_4M_DIMENSION
 
 
 def test_when_get_plan_called_then_generator_returned():


### PR DESCRIPTION
Fixes #34

To test:
* Confirm unit tests still pass (note that `test_given_settings_valid_when_kickoff_then_run_started` is a known failure that is fixed in https://github.com/DiamondLightSource/python-artemis/pull/48
* Also note that this contains changes from #51 so wait until that PR is merged first