### PR TITLE
#117: Created device for backlight and start of snapshot plan

### DIFF
--- a/src/artemis/devices/backlight.py
+++ b/src/artemis/devices/backlight.py
@@ -1,0 +1,8 @@
+from ophyd import Component, Device, EpicsSignal
+
+class Backlight(Device):
+	OUT = 0
+	IN = 1
+	
+	pos: EpicsSignal = Component(EpicsSignal, "-EA-BL-01:CTRL")
+

--- a/src/artemis/snapshot_plan.py
+++ b/src/artemis/snapshot_plan.py
@@ -1,0 +1,13 @@
+from bluesky import RunEngine
+from bluesky.plan_stubs import mv, abs_set, wait
+from devices.backlight import Backlight
+
+backlight = Backlight(name="Backlight", prefix=f"BL03I")
+
+RE = RunEngine({})
+
+def move_then_wait():
+	yield from abs_set(backlight.pos, Backlight.OUT, group='A')
+	yield from wait('A')
+
+RE(move_then_wait())


### PR DESCRIPTION
Fixes #117 

To test:
* `pipenv run python artemis/snapshot_plan.py` moves the backlight