### PR TITLE
125 get undulator gap

### DIFF
--- a/src/artemis/devices/undulator.py
+++ b/src/artemis/devices/undulator.py
@@ -1,0 +1,5 @@
+from ophyd import Component, Device, EpicsMotor
+
+
+class Undulator(Device):
+    gap: EpicsMotor = Component(EpicsMotor, "BLGAPMTR")

--- a/src/artemis/fast_grid_scan_plan.py
+++ b/src/artemis/fast_grid_scan_plan.py
@@ -15,6 +15,7 @@ from ophyd.log import config_ophyd_logging
 from src.artemis.devices.eiger import EigerDetector
 from src.artemis.devices.fast_grid_scan import FastGridScan, set_fast_grid_scan_params
 from src.artemis.devices.zebra import Zebra
+from src.artemis.devices.undulator import Undulator
 from src.artemis.ispyb.store_in_ispyb import StoreInIspyb
 from src.artemis.nexus_writing.write_nexus import NexusWriter
 from src.artemis.parameters import SIM_BEAMLINE, FullParameters
@@ -31,10 +32,20 @@ config_ophyd_logging(file="/tmp/ophyd.log", level="DEBUG")
 # Start analysis run collection
 
 
+def update_params_from_epics(parameters: FullParameters):
+    undulator = Undulator(
+        name="Undulator",
+        prefix=f"{parameters.beamline}-MO-SERVC-01:"
+    )
+    undulator_gap = yield from bps.rd(undulator.gap)
+    parameters.ispyb_params.undulator_gap = undulator_gap
+
+
 @bpp.run_decorator()
 def run_gridscan(
     fgs: FastGridScan, zebra: Zebra, eiger: EigerDetector, parameters: FullParameters
 ):
+    yield from update_params_from_epics(parameters)
     ispyb = StoreInIspyb("config", parameters)
     _, datacollection_id, datacollection_group_id = ispyb.store_grid_scan()
     run_start(datacollection_id)

--- a/src/artemis/fast_grid_scan_plan.py
+++ b/src/artemis/fast_grid_scan_plan.py
@@ -15,8 +15,8 @@ from bluesky.utils import ProgressBarManager
 from ophyd.log import config_ophyd_logging
 from src.artemis.devices.eiger import EigerDetector
 from src.artemis.devices.fast_grid_scan import FastGridScan, set_fast_grid_scan_params
-from src.artemis.devices.zebra import Zebra
 from src.artemis.devices.undulator import Undulator
+from src.artemis.devices.zebra import Zebra
 from src.artemis.ispyb.store_in_ispyb import StoreInIspyb2D, StoreInIspyb3D
 from src.artemis.nexus_writing.write_nexus import NexusWriter
 from src.artemis.parameters import SIM_BEAMLINE, FullParameters
@@ -40,7 +40,11 @@ def update_params_from_epics_devices(parameters: FullParameters, undulator: Undu
 
 @bpp.run_decorator()
 def run_gridscan(
-    fgs: FastGridScan, zebra: Zebra, eiger: EigerDetector, undulator: Undulator, parameters: FullParameters
+    fgs: FastGridScan,
+    zebra: Zebra,
+    eiger: EigerDetector,
+    undulator: Undulator,
+    parameters: FullParameters,
 ):
     yield from update_params_from_epics_devices(parameters, undulator)
     config = "config"
@@ -52,7 +56,7 @@ def run_gridscan(
 
     for id in datacollection_ids:
         run_start(id)
-        
+
     # TODO: Check topup gate
     yield from set_fast_grid_scan_params(fgs, parameters.grid_scan_params)
 
@@ -98,7 +102,9 @@ def get_plan(parameters: FullParameters):
     )
     zebra = Zebra(name="zebra", prefix=f"{parameters.beamline}-EA-ZEBRA-01:")
 
-    undulator = Undulator(name="undulator", prefix=f"{parameters.beamline}-MO-SERVC-01:")
+    undulator = Undulator(
+        name="undulator", prefix=f"{parameters.beamline}-MO-SERVC-01:"
+    )
 
     return run_gridscan(fast_grid_scan, zebra, eiger, undulator, parameters)
 

--- a/src/artemis/fast_grid_scan_plan.py
+++ b/src/artemis/fast_grid_scan_plan.py
@@ -103,7 +103,7 @@ def get_plan(parameters: FullParameters):
     zebra = Zebra(name="zebra", prefix=f"{parameters.beamline}-EA-ZEBRA-01:")
 
     undulator = Undulator(
-        name="undulator", prefix=f"{parameters.beamline}-MO-SERVC-01:"
+        name="undulator", prefix=f"{parameters.insertion_prefix}-MO-SERVC-01:"
     )
 
     return run_gridscan(fast_grid_scan, zebra, eiger, undulator, parameters)

--- a/src/artemis/ispyb/ispyb_dataclass.py
+++ b/src/artemis/ispyb/ispyb_dataclass.py
@@ -10,7 +10,6 @@ from src.artemis.utils import Point2D, Point3D
 @dataclass
 class IspybParams:
     visit_path: str
-    undulator_gap: float
     pixels_per_micron_x: float
     pixels_per_micron_y: float
 
@@ -44,6 +43,8 @@ class IspybParams:
 
     sample_id: Optional[int] = None
     sample_barcode: Optional[str] = None
+    # The following is optional because we are getting it from the EPICS PV
+    undulator_gap: Optional[float] = None
 
 
 class Orientation(Enum):

--- a/src/artemis/parameters.py
+++ b/src/artemis/parameters.py
@@ -7,12 +7,13 @@ from src.artemis.ispyb.ispyb_dataclass import IspybParams
 from src.artemis.utils import Point2D, Point3D
 
 SIM_BEAMLINE = "BL03S"
-
+SIM_INSERTION_PREFIX = "SR03S"
 
 @dataclass_json
 @dataclass
 class FullParameters:
     beamline: str = SIM_BEAMLINE
+    insetrion_prefix: str = SIM_INSERTION_PREFIX
     grid_scan_params: GridScanParams = GridScanParams(
         x_steps=5,
         y_steps=10,

--- a/src/artemis/parameters.py
+++ b/src/artemis/parameters.py
@@ -9,11 +9,12 @@ from src.artemis.utils import Point2D, Point3D
 SIM_BEAMLINE = "BL03S"
 SIM_INSERTION_PREFIX = "SR03S"
 
+
 @dataclass_json
 @dataclass
 class FullParameters:
     beamline: str = SIM_BEAMLINE
-    insetrion_prefix: str = SIM_INSERTION_PREFIX
+    insertion_prefix: str = SIM_INSERTION_PREFIX
     grid_scan_params: GridScanParams = GridScanParams(
         x_steps=5,
         y_steps=10,

--- a/src/artemis/tests/test_fast_grid_scan_plan.py
+++ b/src/artemis/tests/test_fast_grid_scan_plan.py
@@ -1,11 +1,13 @@
 import types
 
-from src.artemis.devices.det_dim_constants import (
-    EIGER2_X_4M_DIMENSION,
-    EIGER_TYPE_EIGER2_X_4M,
-    EIGER_TYPE_EIGER2_X_16M,
-)
-from src.artemis.fast_grid_scan_plan import get_plan
+from bluesky.run_engine import RunEngine
+from ophyd.sim import make_fake_device
+from src.artemis.devices.det_dim_constants import (EIGER2_X_4M_DIMENSION,
+                                                   EIGER_TYPE_EIGER2_X_4M,
+                                                   EIGER_TYPE_EIGER2_X_16M)
+from src.artemis.devices.undulator import Undulator
+from src.artemis.fast_grid_scan_plan import (get_plan,
+                                             update_params_from_epics_devices)
 from src.artemis.parameters import FullParameters
 
 
@@ -23,3 +25,14 @@ def test_given_full_parameters_dict_when_detector_name_used_and_converted_then_d
 def test_when_get_plan_called_then_generator_returned():
     plan = get_plan(FullParameters())
     assert isinstance(plan, types.GeneratorType)
+
+
+def test_parameters_updated_from_epics_devices_correctly():
+    RE = RunEngine({})
+    test_value = 1.234
+    params = FullParameters()
+    FakeUndulator = make_fake_device(Undulator)
+    undulator: Undulator = FakeUndulator(name="undulator")
+    undulator.gap.user_readback.sim_put(test_value)
+    RE(update_params_from_epics_devices(params, undulator))
+    assert params.ispyb_params.undulator_gap == test_value

--- a/src/artemis/tests/test_fast_grid_scan_plan.py
+++ b/src/artemis/tests/test_fast_grid_scan_plan.py
@@ -27,7 +27,7 @@ def test_when_get_plan_called_then_generator_returned():
     assert isinstance(plan, types.GeneratorType)
 
 
-def test_parameters_updated_from_epics_devices_correctly():
+def test_undulator_gap_updated_from_epics_device_correctly():
     RE = RunEngine({})
     test_value = 1.234
     params = FullParameters()


### PR DESCRIPTION
Fixes #125

Undulator device tested using:
```
from bluesky import RunEngine
import bluesky.plan_stubs as bps

undulator = Undulator(name="Undulator", prefix="SR03I-MO-SERVC-01:")

def get_value():
    gap = yield from bps.rd(undulator.gap)
    print(gap)

RE = Runengine({})
RE(get_value())
```
Output was compared with the relevant PV using `caget SR03I-MO-SERVC-01:BLGAPMTR.RBV` and found to be consistent.

Changes needed on the GDA side:
- No longer pass undulator_gap parameter to artemis
- Need to pass insertion_prefix parameter to artemis