### PR TITLE
Startup bash script for deploying, stopping and starting Artemis

### DIFF
--- a/run_artemis.sh
+++ b/run_artemis.sh
@@ -32,7 +32,7 @@ checkver () {
 }
 
 STOP=0
-START=0
+START=1
 DEPLOY=0
 for option in "$@"; do
     case $option in
@@ -47,8 +47,8 @@ for option in "$@"; do
         --stop)
             STOP=1
             ;;
-        --start)
-            START=1
+        --no-start)
+            START=0
             ;;
         --deploy)
             DEPLOY=1
@@ -63,10 +63,10 @@ for option in "$@"; do
             echo "Operations"
             echo "  --stop                  Used to stop a currently running instance of Artemis. Will override any other operations"
             echo "                          options"
-            echo "  --start                 Used to start the Artemis server with the currently installed version."
             echo "  --deploy                Used to update and install a new version of Artemis."
+            echo "  --no-start              Used to specify that the script should be run without starting the server."
             echo " "
-            echo "If no Operations options are specified both --deploy --start will be used by default."
+            echo "By default this script will start an Artemis server unless the --no-start flag is specified."
             exit 0
             ;;
         -*|--*)
@@ -75,11 +75,6 @@ for option in "$@"; do
             ;;
     esac
 done
-
-if [[ $START == 0 && $DEPLOY == 0]]; then
-    START=1
-    DEPLOY=1
-fi
 
 if [[ -z "${BEAMLINE}" ]]; then
     echo "BEAMLINE parameter not set. Use the option -b, --beamline=BEAMLNE to set it manually"

--- a/run_artemis.sh
+++ b/run_artemis.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+# Params - 2 semver strings of the form 1.11.2.3
+# Returns - 0 if equal version, 1 if 1st param is a greater version number, 2 if 2nd param has greater version number
+checkver () {
+    if [[ $1 == $2 ]]
+    then
+        return 0
+    fi
+    local IFS=.
+    local i ver1=($1) ver2=($2)
+    for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
+    do
+        ver1[i]=0
+    done
+    for ((i=0; i<${#ver1[@]}; i++))
+    do
+        if [[ -z ${ver2[i]} ]]
+        then
+            ver2[i]=0
+        fi
+        if ((10#${ver1[i]} > 10#${ver2[i]}))
+        then
+            return 1
+        fi
+        if ((10#${ver1[i]} < 10#${ver2[i]}))
+        then
+            return 2
+        fi
+    done
+    return 0
+}
+
+STOP=0
+START=0
+DEPLOY=0
+for option in "$@"; do
+    case $option in
+        -b=*|--beamline=*)
+            BEAMLINE="${option#*=}"
+            shift
+            ;;
+        -v=*|--version=*)
+            VERSION="${option#*=}"
+            shift
+            ;;
+        --stop)
+            STOP=1
+            ;;
+        --start)
+            START=1
+            ;;
+        --deploy)
+            DEPLOY=1
+            ;;
+        --help|--info)
+            echo "Options"
+            echo "  -b, --beamline=BEAMLINE Overrides the BEAMLINE environment variable with the given beamline"
+            echo "  -v, --version=VERSION   Specifies the artemis version number to deploy. Option should be given in the form 0.0.0.0"
+            echo "                          Will check git tags and use the lastest version as a default if no version is specified."
+            echo "                          Unused outside of deploy operation."
+            echo " "
+            echo "Operations"
+            echo "  --stop                  Used to stop a currently running instance of Artemis. Will override any other operations"
+            echo "                          options"
+            echo "  --start                 Used to start the Artemis server with the currently installed version."
+            echo "  --deploy                Used to update and install a new version of Artemis."
+            echo " "
+            echo "If no Operations options are specified both --deploy --start will be used by default."
+            exit 0
+            ;;
+        -*|--*)
+            echo "Unknown option ${option}. Use --help for info on option usage."
+            exit 1
+            ;;
+    esac
+done
+
+if [[ $START == 0 && $DEPLOY == 0]]; then
+    START=1
+    DEPLOY=1
+fi
+
+if [[ -z "${BEAMLINE}" ]]; then
+    echo "BEAMLINE parameter not set. Use the option -b, --beamline=BEAMLNE to set it manually"
+    exit 1
+fi
+
+SSH_KEY_FILE_LOC="/dls_sw/${BEAMLINE}/software/gda_versions/var/.ssh/${BEAMLINE}-ssh.key"
+
+if [[ $STOP == 1 ]]; then
+    ssh -T -o BatchMode=yes -i ${SSH_KEY_FILE_LOC} gda2@${BEAMLINE}-control.diamond.ac.uk
+    pkill -f src/artemis/main.py
+    exit 0
+fi
+
+ARTEMIS_PATH="/dls_sw/${BEAMLINE}/software/artemis"
+
+if [[ -d "${ARTEMIS_PATH}" ]]; then
+    cd ${ARTEMIS_PATH}
+else
+    echo "Couldn't find artemis installation at ${ARTEMIS_PATH} terminating script"
+    exit 1
+fi
+
+if [[ $DEPLOY == 1 ]]; then
+    git fetch --all --tags --prune
+    if [[ -z "${VERSION}" ]]; then
+        VERSION="0"
+        for version_tag in $(git ls-remote --tags origin/main); do
+            checkver $VERSION ${version_tag}
+            case $? in
+                0|1) ;; # do nothing if VERSION is still the latest version
+                2) VERSION = ${version_tag} ;;
+            esac
+        done
+    fi
+
+    git checkout "tags/${VERSION}"
+
+    pipenv install --python 3.10
+fi
+
+if [[ $START == 1 ]]; then
+    ssh -T -o BatchMode=yes -i ${SSH_KEY_FILE_LOC} gda2@${BEAMLINE}-control.diamond.ac.uk
+
+    if [[ -z $(pgrep -f src/artemis/main.py) ]]; then
+        pkill -f src/artemis.main.py
+    fi
+
+    module unload controls_dev
+    module load python/3.10
+    module load dials
+
+    cd ${ARTEMIS_PATH}
+
+    ISPYB_CONFIG_PATH="/dls_sw/dasc/mariadb/credentials/ispyb-artemis-${BEAMLINE}.cfg"
+
+    export ISPYB_CONFIG_PATH
+
+    pipenv run python src/artemis/main.py &
+fi
+
+sleep 1

--- a/src/artemis/fast_grid_scan_plan.py
+++ b/src/artemis/fast_grid_scan_plan.py
@@ -62,7 +62,7 @@ def run_gridscan(
     yield from update_params_from_epics_devices(
         parameters, undulator, synchrotron, slit_gap
     )
-    ispyb_config = os.environ["ISPYB_CONFIG_PATH"]
+    ispyb_config = os.environ.get("ISPYB_CONFIG_PATH", "TEST_CONFIG")
     ispyb = (
         StoreInIspyb3D(ispyb_config)
         if parameters.grid_scan_params.is_3d_grid_scan

--- a/src/artemis/fast_grid_scan_plan.py
+++ b/src/artemis/fast_grid_scan_plan.py
@@ -62,11 +62,11 @@ def run_gridscan(
     yield from update_params_from_epics_devices(
         parameters, undulator, synchrotron, slit_gap
     )
-    config = "config"
+    ispyb_config = "config"
     ispyb = (
-        StoreInIspyb3D(config)
+        StoreInIspyb3D(ispyb_config)
         if parameters.grid_scan_params.is_3d_grid_scan
-        else StoreInIspyb2D(config)
+        else StoreInIspyb2D(ispyb_config)
     )
 
     datacollection_ids, _, datacollection_group_id = ispyb.store_grid_scan(parameters)

--- a/src/artemis/fast_grid_scan_plan.py
+++ b/src/artemis/fast_grid_scan_plan.py
@@ -62,7 +62,7 @@ def run_gridscan(
     yield from update_params_from_epics_devices(
         parameters, undulator, synchrotron, slit_gap
     )
-    ispyb_config = "config"
+    ispyb_config = os.environ["ISPYB_CONFIG_PATH"]
     ispyb = (
         StoreInIspyb3D(ispyb_config)
         if parameters.grid_scan_params.is_3d_grid_scan

--- a/src/artemis/tests/test_fast_grid_scan_plan.py
+++ b/src/artemis/tests/test_fast_grid_scan_plan.py
@@ -1,3 +1,4 @@
+import os
 import types
 from unittest.mock import call, patch
 
@@ -71,6 +72,7 @@ def test_ispyb_params_update_from_ophyd_devices_correctly():
     assert params.ispyb_params.slit_gap_size_y == ygap_test_value
 
 
+@patch.dict(os.environ, {"ISPYB_CONFIG_PATH": "TEST_CONFIG"})
 @patch("src.artemis.fast_grid_scan_plan.run_start")
 @patch("src.artemis.fast_grid_scan_plan.run_end")
 @patch("src.artemis.fast_grid_scan_plan.wait_for_result")

--- a/src/artemis/tests/test_fast_grid_scan_plan.py
+++ b/src/artemis/tests/test_fast_grid_scan_plan.py
@@ -72,7 +72,6 @@ def test_ispyb_params_update_from_ophyd_devices_correctly():
     assert params.ispyb_params.slit_gap_size_y == ygap_test_value
 
 
-@patch.dict(os.environ, {"ISPYB_CONFIG_PATH": "TEST_CONFIG"})
 @patch("src.artemis.fast_grid_scan_plan.run_start")
 @patch("src.artemis.fast_grid_scan_plan.run_end")
 @patch("src.artemis.fast_grid_scan_plan.wait_for_result")


### PR DESCRIPTION
Fixes #163

Current behaviour -

Will fail if --deploy is run and the user running the script is not in dls_dasc group due to file permissions. Permissions will ned changing to resolve this (although it may not be such a bad thing for dls_dasc to be the only group with permission to deploy new versions)

By default the script at the moment will both start and deploy a new Artemis version. --deploy and --start flags are used to only perform those actions. The other option I could think of would be to have the default action be just starting the server and have --deploy only deploy and use both tags (--deploy --start) to perform both actions.

The --stop flag will currently override the --start and --deploy flags and only stop the currently running artemis.

If any of these should/could be changed let me know in the review,