### PR TITLE
Edit config files so that the correct coverage reports are produced

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,5 @@ build-backend = "setuptools.build_meta"
 markers = [
     "s03: marks tests as requiring the s03 simulator running (deselect with '-m \"not s03\"')",
 ]
+addopts = "--cov=src/artemis --cov-report term --cov-report xml:cov.xml"
+testpaths = "src"

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,13 +59,6 @@ extend-ignore =
     E203,  # See https://github.com/PyCQA/pycodestyle/issues/373
     F811,  # support typing.overload decorator
 
-[tool:pytest]
-# Run pytest with all our checkers, and don't spam us with massive tracebacks on error
-addopts =
-    --cov=python-artemis --cov-report term --cov-report xml:cov.xml
-filterwarnings = error
-testpaths = src
-
 [coverage:run]
 # This is covered in the versiongit test suite so exclude it here
 omit = */_version_git.py


### PR DESCRIPTION
Fixes an issue introduced in #190, whereby the coverage CI was slightly broken due to pytest not using setup.cfg as its configuration file.