### PR TITLE
Use artemis-specific zocalo environment

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ max-line-length = 88
 extend-ignore =
     E203,  # See https://github.com/PyCQA/pycodestyle/issues/373
     F811,  # support typing.overload decorator
+    E501,  # line too long
 
 [coverage:run]
 # This is covered in the versiongit test suite so exclude it here

--- a/src/artemis/tests/test_zocalo_interaction.py
+++ b/src/artemis/tests/test_zocalo_interaction.py
@@ -34,7 +34,7 @@ def _test_zocalo(
 
     func_testing(mock_transport)
 
-    mock_zc.activate.assert_called_once()
+    mock_zc.activate_environment.assert_called_once_with("artemis")
     mock_transport.connect.assert_called_once()
     expected_message = {
         "recipes": ["mimas"],

--- a/src/artemis/zocalo_interaction.py
+++ b/src/artemis/zocalo_interaction.py
@@ -1,7 +1,6 @@
 import getpass
 import queue
 import socket
-from time import sleep
 
 import workflows.recipe
 import workflows.transport
@@ -15,7 +14,7 @@ TIMEOUT = 30
 
 def _get_zocalo_connection():
     zc = zocalo.configuration.from_file()
-    zc.activate()
+    zc.activate_environment("artemis")
 
     transport = lookup("PikaTransport")()
     transport.connect()

--- a/src/artemis/zocalo_interaction.py
+++ b/src/artemis/zocalo_interaction.py
@@ -41,20 +41,22 @@ def _send_to_zocalo(parameters: dict):
 
 def run_start(data_collection_id: int):
     """Tells the data analysis pipeline we have started a grid scan.
-    Assumes that appropriate data has already been put into ISpyB
+    Assumes that appropriate data has already been put into ISPyB
 
     Args:
-        data_collection_id (int): The ID of the data collection representing the gridscan in ISpyB
+        data_collection_id (int): The ID of the data collection representing the
+                                  gridscan in ISPyB
     """
     _send_to_zocalo({"event": "start", "ispyb_dcid": data_collection_id})
 
 
 def run_end(data_collection_id: int):
     """Tells the data analysis pipeline we have finished a grid scan.
-    Assumes that appropriate data has already been put into ISpyB
+    Assumes that appropriate data has already been put into ISPyB
 
     Args:
-        data_collection_id (int): The ID of the data collection representing the gridscan in ISpyB
+        data_collection_id (int): The ID of the data collection representing the
+                                  gridscan in ISPyB
     """
     _send_to_zocalo(
         {
@@ -68,7 +70,8 @@ def run_end(data_collection_id: int):
 def wait_for_result(data_collection_group_id: int, timeout: int = TIMEOUT) -> Point3D:
     """Block until a result is received from Zocalo.
     Args:
-        data_collection_group_id (int): The ID of the data collection group representing the gridscan in ISpyB
+        data_collection_group_id (int): The ID of the data collection group representing
+                                        the gridscan in ISPyB
         timeout (float): The time in seconds to wait for the result to be received.
     Returns:
         Point in grid co-ordinates that is the centre point to move to


### PR DESCRIPTION
This avoids bluesky logs ending up in the Zocalo/data analysis graylog stream.

See also https://github.com/DiamondLightSource/python-artemis/issues/27

Add E501 to flake ignore: Since we are already relying on black to apply an appropriate max line length, and flake8 can sometimes disagree ignore this particular warning