### PR TITLE
Remove use of src in imports

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,10 @@ dev =
 [options.packages.find]
 where = src
 
+[options.package_data]
+artemis =
+    *.txt
+
 [mypy]
 # Ignore missing stubs for modules we use
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ dev =
 where = src
 
 [options.package_data]
-artemis =
+artemis.devices =
     *.txt
 
 [mypy]

--- a/src/artemis/devices/detector.py
+++ b/src/artemis/devices/detector.py
@@ -3,13 +3,14 @@ from dataclasses import dataclass, field
 from typing import Tuple
 
 from dataclasses_json import config, dataclass_json
-from src.artemis.devices.det_dim_constants import (
+
+from artemis.devices.det_dim_constants import (
     EIGER2_X_16M_SIZE,
     DetectorSize,
     DetectorSizeConstants,
     constants_from_type,
 )
-from src.artemis.devices.det_dist_to_beam_converter import (
+from artemis.devices.det_dist_to_beam_converter import (
     Axis,
     DetectorDistanceToBeamXYConverter,
 )

--- a/src/artemis/devices/eiger.py
+++ b/src/artemis/devices/eiger.py
@@ -4,9 +4,9 @@ from ophyd import Component, Device, EpicsSignalRO
 from ophyd.areadetector.cam import EigerDetectorCam
 from ophyd.utils.epics_pvs import set_and_wait
 
-from src.artemis.devices.detector import DetectorParams
-from src.artemis.devices.eiger_odin import EigerOdin
-from src.artemis.devices.status import await_value
+from artemis.devices.detector import DetectorParams
+from artemis.devices.eiger_odin import EigerOdin
+from artemis.devices.status import await_value
 
 
 class EigerTriggerMode(Enum):

--- a/src/artemis/devices/eiger_odin.py
+++ b/src/artemis/devices/eiger_odin.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 from ophyd import Component, Device, EpicsSignal, EpicsSignalRO, EpicsSignalWithRBV
 from ophyd.areadetector.plugins import HDF5Plugin_V22
 
-from src.artemis.devices.status import await_value
+from artemis.devices.status import await_value
 
 
 class EigerFan(Device):

--- a/src/artemis/devices/fast_grid_scan.py
+++ b/src/artemis/devices/fast_grid_scan.py
@@ -15,9 +15,10 @@ from ophyd import (
 )
 from ophyd.status import DeviceStatus, StatusBase
 from ophyd.utils.epics_pvs import set_and_wait
-from src.artemis.devices.motors import XYZLimitBundle
-from src.artemis.devices.status import await_value
-from src.artemis.utils import Point3D
+
+from artemis.devices.motors import XYZLimitBundle
+from artemis.devices.status import await_value
+from artemis.utils import Point3D
 
 
 @dataclass

--- a/src/artemis/devices/fast_grid_scan_composite.py
+++ b/src/artemis/devices/fast_grid_scan_composite.py
@@ -1,11 +1,11 @@
 from ophyd import Component, Device, FormattedComponent
 
-from src.artemis.devices.fast_grid_scan import FastGridScan
-from src.artemis.devices.motors import I03Smargon
-from src.artemis.devices.slit_gaps import SlitGaps
-from src.artemis.devices.synchrotron import Synchrotron
-from src.artemis.devices.undulator import Undulator
-from src.artemis.devices.zebra import Zebra
+from artemis.devices.fast_grid_scan import FastGridScan
+from artemis.devices.motors import I03Smargon
+from artemis.devices.slit_gaps import SlitGaps
+from artemis.devices.synchrotron import Synchrotron
+from artemis.devices.undulator import Undulator
+from artemis.devices.zebra import Zebra
 
 
 class FGSComposite(Device):

--- a/src/artemis/devices/oav/__init__.py
+++ b/src/artemis/devices/oav/__init__.py
@@ -9,7 +9,7 @@ from ophyd import (
     ROIPlugin,
 )
 
-from src.artemis.devices.oav.grid_overlay import SnapshotWithGrid
+from artemis.devices.oav.grid_overlay import SnapshotWithGrid
 
 
 class OAV(AreaDetector):

--- a/src/artemis/devices/oav/grid_overlay.py
+++ b/src/artemis/devices/oav/grid_overlay.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from ophyd import Component, Signal
 from PIL import Image, ImageDraw
 
-from src.artemis.devices.oav.snapshot import Snapshot
+from artemis.devices.oav.snapshot import Snapshot
 
 
 class Orientation(Enum):

--- a/src/artemis/devices/system_tests/test_eiger_system.py
+++ b/src/artemis/devices/system_tests/test_eiger_system.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
-from src.artemis.devices.eiger import DetectorParams, EigerDetector
+
+from artemis.devices.eiger import DetectorParams, EigerDetector
 
 
 @pytest.fixture()

--- a/src/artemis/devices/system_tests/test_gridscan_system.py
+++ b/src/artemis/devices/system_tests/test_gridscan_system.py
@@ -1,7 +1,7 @@
 import pytest
 from bluesky.run_engine import RunEngine
 
-from src.artemis.devices.fast_grid_scan import (
+from artemis.devices.fast_grid_scan import (
     FastGridScan,
     GridScanParams,
     set_fast_grid_scan_params,

--- a/src/artemis/devices/system_tests/test_oav_system.py
+++ b/src/artemis/devices/system_tests/test_oav_system.py
@@ -2,7 +2,7 @@ import bluesky.plan_stubs as bps
 import pytest
 from bluesky import RunEngine
 
-from src.artemis.devices.oav import OAV
+from artemis.devices.oav import OAV
 
 TEST_GRID_TOP_LEFT_X = 100
 TEST_GRID_TOP_LEFT_Y = 100

--- a/src/artemis/devices/system_tests/test_zebra_system.py
+++ b/src/artemis/devices/system_tests/test_zebra_system.py
@@ -1,13 +1,13 @@
 import pytest
 
-from src.artemis.devices.zebra import (
-    Zebra,
-    TTL_DETECTOR,
-    TTL_SHUTTER,
-    PC_PULSE,
-    OR1,
+from artemis.devices.zebra import (
     IN3_TTL,
     IN4_TTL,
+    OR1,
+    PC_PULSE,
+    TTL_DETECTOR,
+    TTL_SHUTTER,
+    Zebra,
 )
 
 

--- a/src/artemis/devices/unit_tests/test_aperture.py
+++ b/src/artemis/devices/unit_tests/test_aperture.py
@@ -1,7 +1,7 @@
 import pytest
 from ophyd.sim import make_fake_device
 
-from src.artemis.devices.aperture import Aperture
+from artemis.devices.aperture import Aperture
 
 
 @pytest.fixture

--- a/src/artemis/devices/unit_tests/test_backlight.py
+++ b/src/artemis/devices/unit_tests/test_backlight.py
@@ -1,7 +1,7 @@
 import pytest
 from ophyd.sim import make_fake_device
 
-from src.artemis.devices.backlight import Backlight
+from artemis.devices.backlight import Backlight
 
 
 @pytest.fixture

--- a/src/artemis/devices/unit_tests/test_beam_converter.py
+++ b/src/artemis/devices/unit_tests/test_beam_converter.py
@@ -1,6 +1,7 @@
 import pytest
 from mockito import when
-from src.artemis.devices.det_dist_to_beam_converter import (
+
+from artemis.devices.det_dist_to_beam_converter import (
     Axis,
     DetectorDistanceToBeamXYConverter,
 )

--- a/src/artemis/devices/unit_tests/test_det_dim_constants.py
+++ b/src/artemis/devices/unit_tests/test_det_dim_constants.py
@@ -1,6 +1,6 @@
 import pytest
 
-from src.artemis.devices.det_dim_constants import (
+from artemis.devices.det_dim_constants import (
     EIGER2_X_4M_DIMENSION_X,
     EIGER_TYPE_EIGER2_X_4M,
     constants_from_type,

--- a/src/artemis/devices/unit_tests/test_eiger.py
+++ b/src/artemis/devices/unit_tests/test_eiger.py
@@ -5,9 +5,9 @@ from mockito import ANY, mock, verify, when
 from ophyd.sim import make_fake_device
 from ophyd.status import Status
 
-from src.artemis.devices.det_dim_constants import EIGER2_X_16M_SIZE
-from src.artemis.devices.detector import DetectorParams
-from src.artemis.devices.eiger import EigerDetector
+from artemis.devices.det_dim_constants import EIGER2_X_16M_SIZE
+from artemis.devices.detector import DetectorParams
+from artemis.devices.eiger import EigerDetector
 
 TEST_DETECTOR_SIZE_CONSTANTS = EIGER2_X_16M_SIZE
 
@@ -134,7 +134,7 @@ def test_stage_raises_exception_if_odin_initialisation_status_not_ok(fake_eiger)
 @pytest.mark.parametrize(
     "roi_mode, expected_num_roi_enable_calls", [(True, 1), (False, 0)]
 )
-@patch("src.artemis.devices.eiger.await_value")
+@patch("artemis.devices.eiger.await_value")
 def test_stage_enables_roi_mode_correctly(
     mock_await, fake_eiger, roi_mode, expected_num_roi_enable_calls
 ):
@@ -207,7 +207,7 @@ def test_unsuccessful_roi_mode_change_results_in_logged_error(mock_and, fake_eig
     fake_eiger.log.error.assert_called_once_with("Failed to switch to ROI mode")
 
 
-@patch("src.artemis.devices.eiger.EigerOdin.check_odin_state")
+@patch("artemis.devices.eiger.EigerOdin.check_odin_state")
 def test_bad_odin_state_results_in_unstage_returning_bad_status(
     mock_check_odin_state, fake_eiger
 ):
@@ -226,7 +226,7 @@ def test_given_failing_odin_when_stage_then_exception_raised(fake_eiger):
         assert error_contents in e.value
 
 
-@patch("src.artemis.devices.eiger.await_value")
+@patch("artemis.devices.eiger.await_value")
 def test_stage_runs_successfully(mock_await, fake_eiger):
     fake_eiger.odin.nodes.clear_odin_errors = MagicMock()
     fake_eiger.odin.check_odin_initialised = MagicMock()

--- a/src/artemis/devices/unit_tests/test_grid_overlay.py
+++ b/src/artemis/devices/unit_tests/test_grid_overlay.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from src.artemis.devices.oav.grid_overlay import (
+from artemis.devices.oav.grid_overlay import (
     add_grid_border_overlay_to_image,
     add_grid_overlay_to_image,
 )
@@ -47,7 +47,7 @@ def _test_expected_calls_to_image_draw_line(mock_image_draw: MagicMock, expected
         ),
     ],
 )
-@patch("src.artemis.devices.oav.grid_overlay.ImageDraw.Draw")
+@patch("artemis.devices.oav.grid_overlay.ImageDraw.Draw")
 def test_add_grid_border_overlay_to_image_makes_correct_calls_to_imagedraw(
     mock_imagedraw: MagicMock,
     top_left_x,
@@ -97,7 +97,7 @@ def test_add_grid_border_overlay_to_image_makes_correct_calls_to_imagedraw(
         ),
     ],
 )
-@patch("src.artemis.devices.oav.grid_overlay.ImageDraw.Draw")
+@patch("artemis.devices.oav.grid_overlay.ImageDraw.Draw")
 def test_add_grid_overlay_to_image_makes_correct_calls_to_imagedraw(
     mock_imagedraw: MagicMock,
     top_left_x,

--- a/src/artemis/devices/unit_tests/test_gridscan.py
+++ b/src/artemis/devices/unit_tests/test_gridscan.py
@@ -3,14 +3,15 @@ from bluesky.run_engine import RunEngine
 from mockito import mock, unstub, verify, when
 from mockito.matchers import ANY, ARGS, KWARGS
 from ophyd.sim import make_fake_device
-from src.artemis.devices.fast_grid_scan import (
+
+from artemis.devices.fast_grid_scan import (
     FastGridScan,
     GridScanParams,
     set_fast_grid_scan_params,
     time,
 )
-from src.artemis.devices.motors import I03Smargon
-from src.artemis.utils import Point3D
+from artemis.devices.motors import I03Smargon
+from artemis.utils import Point3D
 
 
 @pytest.fixture

--- a/src/artemis/devices/unit_tests/test_oav.py
+++ b/src/artemis/devices/unit_tests/test_oav.py
@@ -6,7 +6,7 @@ import pytest
 from ophyd.sim import make_fake_device
 from requests import HTTPError, Response
 
-from src.artemis.devices.oav import OAV
+from artemis.devices.oav import OAV
 
 
 @pytest.fixture
@@ -39,7 +39,7 @@ def test_snapshot_trigger_handles_request_with_bad_status_code_correctly(
 
 
 @patch("requests.get")
-@patch("src.artemis.devices.oav.snapshot.Image")
+@patch("artemis.devices.oav.snapshot.Image")
 def test_snapshot_trigger_loads_correct_url(mock_image, mock_get: MagicMock, fake_oav):
     st = fake_oav.snapshot.trigger()
     st.wait()
@@ -47,7 +47,7 @@ def test_snapshot_trigger_loads_correct_url(mock_image, mock_get: MagicMock, fak
 
 
 @patch("requests.get")
-@patch("src.artemis.devices.oav.snapshot.Image.open")
+@patch("artemis.devices.oav.snapshot.Image.open")
 def test_snapshot_trigger_saves_to_correct_file(
     mock_open: MagicMock, mock_get, fake_oav
 ):
@@ -66,9 +66,9 @@ def test_snapshot_trigger_saves_to_correct_file(
 
 
 @patch("requests.get")
-@patch("src.artemis.devices.oav.snapshot.Image.open")
-@patch("src.artemis.devices.oav.grid_overlay.add_grid_overlay_to_image")
-@patch("src.artemis.devices.oav.grid_overlay.add_grid_border_overlay_to_image")
+@patch("artemis.devices.oav.snapshot.Image.open")
+@patch("artemis.devices.oav.grid_overlay.add_grid_overlay_to_image")
+@patch("artemis.devices.oav.grid_overlay.add_grid_border_overlay_to_image")
 def test_correct_grid_drawn_on_image(
     mock_border_overlay: MagicMock,
     mock_grid_overlay: MagicMock,

--- a/src/artemis/devices/unit_tests/test_odin.py
+++ b/src/artemis/devices/unit_tests/test_odin.py
@@ -2,7 +2,7 @@ import pytest
 from mockito import when
 from ophyd.sim import make_fake_device
 
-from src.artemis.devices.eiger_odin import EigerOdin
+from artemis.devices.eiger_odin import EigerOdin
 
 
 @pytest.fixture

--- a/src/artemis/devices/unit_tests/test_zebra.py
+++ b/src/artemis/devices/unit_tests/test_zebra.py
@@ -2,7 +2,7 @@ import pytest
 from mockito import mock, verify
 from ophyd.sim import make_fake_device
 
-from src.artemis.devices.zebra import (
+from artemis.devices.zebra import (
     GateType,
     LogicGateConfiguration,
     LogicGateConfigurer,

--- a/src/artemis/devices/zebra.py
+++ b/src/artemis/devices/zebra.py
@@ -7,7 +7,7 @@ from typing import List
 from ophyd import Component, Device, EpicsSignal, StatusBase
 from ophyd.status import SubscriptionStatus
 
-from src.artemis.devices.utils import epics_signal_put_wait
+from artemis.devices.utils import epics_signal_put_wait
 
 PC_ARM_SOURCE_SOFT = 0
 PC_ARM_SOURCE_EXT = 1

--- a/src/artemis/fast_grid_scan_plan.py
+++ b/src/artemis/fast_grid_scan_plan.py
@@ -8,16 +8,16 @@ from bluesky.log import config_bluesky_logging
 from bluesky.utils import ProgressBarManager
 from ophyd.log import config_ophyd_logging
 
-from src.artemis.devices.eiger import EigerDetector
-from src.artemis.devices.fast_grid_scan import set_fast_grid_scan_params
-from src.artemis.devices.fast_grid_scan_composite import FGSComposite
-from src.artemis.devices.slit_gaps import SlitGaps
-from src.artemis.devices.synchrotron import Synchrotron
-from src.artemis.devices.undulator import Undulator
-from src.artemis.ispyb.store_in_ispyb import StoreInIspyb2D, StoreInIspyb3D
-from src.artemis.nexus_writing.write_nexus import NexusWriter
-from src.artemis.parameters import SIM_BEAMLINE, FullParameters
-from src.artemis.zocalo_interaction import run_end, run_start, wait_for_result
+from artemis.devices.eiger import EigerDetector
+from artemis.devices.fast_grid_scan import set_fast_grid_scan_params
+from artemis.devices.fast_grid_scan_composite import FGSComposite
+from artemis.devices.slit_gaps import SlitGaps
+from artemis.devices.synchrotron import Synchrotron
+from artemis.devices.undulator import Undulator
+from artemis.ispyb.store_in_ispyb import StoreInIspyb2D, StoreInIspyb3D
+from artemis.nexus_writing.write_nexus import NexusWriter
+from artemis.parameters import SIM_BEAMLINE, FullParameters
+from artemis.zocalo_interaction import run_end, run_start, wait_for_result
 
 config_bluesky_logging(file="/tmp/bluesky.log", level="DEBUG")
 config_ophyd_logging(file="/tmp/ophyd.log", level="DEBUG")

--- a/src/artemis/ispyb/ispyb_dataclass.py
+++ b/src/artemis/ispyb/ispyb_dataclass.py
@@ -3,7 +3,8 @@ from enum import Enum
 from typing import List, Optional
 
 from dataclasses_json import config, dataclass_json
-from src.artemis.utils import Point2D, Point3D
+
+from artemis.utils import Point2D, Point3D
 
 
 @dataclass_json

--- a/src/artemis/ispyb/store_in_ispyb.py
+++ b/src/artemis/ispyb/store_in_ispyb.py
@@ -5,8 +5,8 @@ from abc import ABC, abstractmethod
 import ispyb
 from sqlalchemy.connectors import Connector
 
-from src.artemis.ispyb.ispyb_dataclass import Orientation
-from src.artemis.parameters import FullParameters
+from artemis.ispyb.ispyb_dataclass import Orientation
+from artemis.parameters import FullParameters
 
 I03_EIGER_DETECTOR = 78
 EIGER_FILE_SUFFIX = "h5"

--- a/src/artemis/ispyb/tests/test_store_in_ispyb.py
+++ b/src/artemis/ispyb/tests/test_store_in_ispyb.py
@@ -6,8 +6,8 @@ import pytest
 from ispyb.sp.mxacquisition import MXAcquisition
 from mockito import ANY, arg_that, mock, verify, when
 
-from src.artemis.ispyb.store_in_ispyb import StoreInIspyb2D, StoreInIspyb3D
-from src.artemis.parameters import FullParameters
+from artemis.ispyb.store_in_ispyb import StoreInIspyb2D, StoreInIspyb3D
+from artemis.parameters import FullParameters
 
 TEST_DATA_COLLECTION_ID = 12
 TEST_DATA_COLLECTION_GROUP_ID = 34

--- a/src/artemis/nexus_writing/tests/test_write_nexus.py
+++ b/src/artemis/nexus_writing/tests/test_write_nexus.py
@@ -5,8 +5,8 @@ from unittest.mock import call, patch
 import h5py
 import pytest
 
-from src.artemis.nexus_writing.write_nexus import NexusWriter
-from src.artemis.parameters import FullParameters
+from artemis.nexus_writing.write_nexus import NexusWriter
+from artemis.parameters import FullParameters
 
 """It's hard to effectively unit test the nexus writing so these are really system tests
 that confirms that we're passing the right sorts of data to nexgen to get a sensible output.

--- a/src/artemis/nexus_writing/write_nexus.py
+++ b/src/artemis/nexus_writing/write_nexus.py
@@ -15,10 +15,10 @@ from nexgen.nxs_write.NexusWriter import ScanReader, call_writers
 from nexgen.nxs_write.NXclassWriters import write_NXentry
 from nexgen.tools.VDS_tools import image_vds_writer
 
-from src.artemis.devices.detector import DetectorParams
-from src.artemis.devices.fast_grid_scan import GridScanParams
-from src.artemis.ispyb.ispyb_dataclass import IspybParams
-from src.artemis.parameters import FullParameters
+from artemis.devices.detector import DetectorParams
+from artemis.devices.fast_grid_scan import GridScanParams
+from artemis.ispyb.ispyb_dataclass import IspybParams
+from artemis.parameters import FullParameters
 
 source = {
     "name": "Diamond Light Source",

--- a/src/artemis/parameters.py
+++ b/src/artemis/parameters.py
@@ -3,10 +3,10 @@ from dataclasses import dataclass, field
 
 from dataclasses_json import dataclass_json
 
-from src.artemis.devices.eiger import DetectorParams
-from src.artemis.devices.fast_grid_scan import GridScanParams
-from src.artemis.ispyb.ispyb_dataclass import IspybParams
-from src.artemis.utils import Point2D, Point3D
+from artemis.devices.eiger import DetectorParams
+from artemis.devices.fast_grid_scan import GridScanParams
+from artemis.ispyb.ispyb_dataclass import IspybParams
+from artemis.utils import Point2D, Point3D
 
 SIM_BEAMLINE = "BL03S"
 SIM_INSERTION_PREFIX = "SR03S"

--- a/src/artemis/snapshot_plan.py
+++ b/src/artemis/snapshot_plan.py
@@ -2,9 +2,9 @@ import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
 from bluesky import RunEngine
 
-from src.artemis.devices.aperture import Aperture
-from src.artemis.devices.backlight import Backlight
-from src.artemis.devices.oav import OAV
+from artemis.devices.aperture import Aperture
+from artemis.devices.backlight import Backlight
+from artemis.devices.oav import OAV
 
 
 def prepare_for_snapshot(backlight: Backlight, aperture: Aperture):

--- a/src/artemis/tests/test_fast_grid_scan_plan.py
+++ b/src/artemis/tests/test_fast_grid_scan_plan.py
@@ -5,22 +5,19 @@ from bluesky.run_engine import RunEngine
 from mockito import ANY, when
 from ophyd.sim import make_fake_device
 
-from src.artemis.devices.det_dim_constants import (
+from artemis.devices.det_dim_constants import (
     EIGER2_X_4M_DIMENSION,
     EIGER_TYPE_EIGER2_X_4M,
     EIGER_TYPE_EIGER2_X_16M,
 )
-from src.artemis.devices.eiger import EigerDetector
-from src.artemis.devices.fast_grid_scan_composite import FGSComposite
-from src.artemis.devices.slit_gaps import SlitGaps
-from src.artemis.devices.synchrotron import Synchrotron
-from src.artemis.devices.undulator import Undulator
-from src.artemis.fast_grid_scan_plan import (
-    run_gridscan,
-    update_params_from_epics_devices,
-)
-from src.artemis.ispyb.store_in_ispyb import StoreInIspyb3D
-from src.artemis.parameters import FullParameters
+from artemis.devices.eiger import EigerDetector
+from artemis.devices.fast_grid_scan_composite import FGSComposite
+from artemis.devices.slit_gaps import SlitGaps
+from artemis.devices.synchrotron import Synchrotron
+from artemis.devices.undulator import Undulator
+from artemis.fast_grid_scan_plan import run_gridscan, update_params_from_epics_devices
+from artemis.ispyb.store_in_ispyb import StoreInIspyb3D
+from artemis.parameters import FullParameters
 
 DUMMY_TIME_STRING = "1970-01-01 00:00:00"
 
@@ -70,9 +67,9 @@ def test_ispyb_params_update_from_ophyd_devices_correctly():
     assert params.ispyb_params.slit_gap_size_y == ygap_test_value
 
 
-@patch("src.artemis.fast_grid_scan_plan.run_start")
-@patch("src.artemis.fast_grid_scan_plan.run_end")
-@patch("src.artemis.fast_grid_scan_plan.wait_for_result")
+@patch("artemis.fast_grid_scan_plan.run_start")
+@patch("artemis.fast_grid_scan_plan.run_end")
+@patch("artemis.fast_grid_scan_plan.wait_for_result")
 def test_run_gridscan_zocalo_calls(wait_for_result, run_end, run_start):
     dc_ids = [1, 2]
     dcg_id = 4
@@ -96,7 +93,7 @@ def test_run_gridscan_zocalo_calls(wait_for_result, run_end, run_start):
         DUMMY_TIME_STRING, "DataCollection Successful", ANY(int), dcg_id
     )
 
-    with patch("src.artemis.fast_grid_scan_plan.NexusWriter"):
+    with patch("artemis.fast_grid_scan_plan.NexusWriter"):
         list(run_gridscan(fgs_composite, eiger, params))
 
     run_start.assert_has_calls(call(x) for x in dc_ids)

--- a/src/artemis/tests/test_main_system.py
+++ b/src/artemis/tests/test_main_system.py
@@ -8,8 +8,8 @@ from unittest.mock import patch
 import pytest
 from flask.testing import FlaskClient
 
-from src.artemis.__main__ import Actions, Status, create_app
-from src.artemis.parameters import FullParameters
+from artemis.__main__ import Actions, Status, create_app
+from artemis.parameters import FullParameters
 
 FGS_ENDPOINT = "/fast_grid_scan/"
 START_ENDPOINT = FGS_ENDPOINT + Actions.START.value
@@ -51,7 +51,7 @@ def test_env():
     runner_thread = threading.Thread(target=runner.wait_on_queue)
     runner_thread.start()
     with app.test_client() as client:
-        with patch("src.artemis.__main__.get_plan") as _:
+        with patch("artemis.__main__.get_plan") as _:
             yield ClientAndRunEngine(client, mock_run_engine)
 
     runner.shutdown()

--- a/src/artemis/tests/test_parameters.py
+++ b/src/artemis/tests/test_parameters.py
@@ -1,4 +1,4 @@
-from src.artemis.parameters import FullParameters
+from artemis.parameters import FullParameters
 
 
 def test_new_parameters_is_a_deep_copy():

--- a/src/artemis/tests/test_zocalo_interaction.py
+++ b/src/artemis/tests/test_zocalo_interaction.py
@@ -9,8 +9,8 @@ from unittest.mock import MagicMock, patch
 from pytest import mark, raises
 from zocalo.configuration import Configuration
 
-from src.artemis.ispyb.ispyb_dataclass import Point3D
-from src.artemis.zocalo_interaction import run_end, run_start, wait_for_result
+from artemis.ispyb.ispyb_dataclass import Point3D
+from artemis.zocalo_interaction import run_end, run_start, wait_for_result
 
 EXPECTED_DCID = 100
 EXPECTED_RUN_START_MESSAGE = {"event": "start", "ispyb_dcid": EXPECTED_DCID}
@@ -22,7 +22,7 @@ EXPECTED_RUN_END_MESSAGE = {
 
 
 @patch("zocalo.configuration.from_file")
-@patch("src.artemis.zocalo_interaction.lookup")
+@patch("artemis.zocalo_interaction.lookup")
 def _test_zocalo(
     func_testing: Callable, expected_params: dict, mock_transport_lookup, mock_from_file
 ):
@@ -87,7 +87,7 @@ def test_run_start_and_end(
 
 @patch("workflows.recipe.wrap_subscribe")
 @patch("zocalo.configuration.from_file")
-@patch("src.artemis.zocalo_interaction.lookup")
+@patch("artemis.zocalo_interaction.lookup")
 def test_when_message_recieved_from_zocalo_then_point_returned(
     mock_transport_lookup, mock_from_file, mock_wrap_subscribe
 ):

--- a/src/artemis/zocalo_interaction.py
+++ b/src/artemis/zocalo_interaction.py
@@ -7,7 +7,7 @@ import workflows.transport
 import zocalo.configuration
 from workflows.transport import lookup
 
-from src.artemis.utils import Point3D
+from artemis.utils import Point3D
 
 TIMEOUT = 30
 


### PR DESCRIPTION
Since changing how we build we no longer need to specify `src`, this removes it.

To test:
* Confirm all tests still pass