### PR TITLE
27 integrate with graylog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 # gedit backup files
 *~
+
+# Log files
+/tmp

--- a/Pipfile
+++ b/Pipfile
@@ -19,4 +19,4 @@ allow_prereleases = true
 tests = "pytest -m \"not s03\""
 build = "python setup.py sdist bdist_wheel"
 gitclean = "git clean -fdX"
-main = "python -m artemis"
+artemis = "python -m artemis"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Starting the bluesky runner
 -------------------------
 You can start the bluesky runner by doing the following:
 ```
-pipenv run main
+pipenv run artemis
 ```
 
 Starting a scan
@@ -37,7 +37,7 @@ Starting a scan
 
 To start a scan you can do the following:
 ```
-curl -X PUT http://127.0.0.1:5000/fast_grid_scan/start --data-binary "@test_parameters.json" -H "Content-Type: application/json"
+curl -X PUT http://127.0.0.1:5003/fast_grid_scan/start --data-binary "@test_parameters.json" -H "Content-Type: application/json"
 ```
 
 Getting the Runner Status
@@ -45,7 +45,7 @@ Getting the Runner Status
 
 To get the status of the runner:
 ```
-curl http://127.0.0.1:5000/fast_grid_scan/status
+curl http://127.0.0.1:5003/fast_grid_scan/status
 ```
 
 Stopping the Scan
@@ -53,7 +53,7 @@ Stopping the Scan
 
 To stop a scan that is currently running:
 ```
-curl -X PUT http://127.0.0.1:5000/fast_grid_scan/stop
+curl -X PUT http://127.0.0.1:5003/fast_grid_scan/stop
 
 ```
 
@@ -62,4 +62,10 @@ For running local dev logging
 ------------------------------
 For development logs a local instance of graylog is needed. This needs to be run with both a mongo and elastic search instance. To set this up and run up the containers on your local machine run the `setup_graylog.sh` script.
 
-This uses the generic defaults for a local graylog instance. It can be accessed on `localhost:9000` where the username and password for the graylog portal are both admin.
+This uses the generic defaults for a local graylog instance. It can be accessed on `localhost:9000` where the username and password for the graylog portal are both admin. To run artemis in this mode use the `--dev` flag with the run command.
+
+You can also choose the logging level, like:
+```
+pipenv run artemis --dev --logging-level DEBUG
+```
+Without these flags the default behaviour will log to production graylog logs (not yet) with a logging level of INFO.

--- a/README.md
+++ b/README.md
@@ -54,4 +54,31 @@ Stopping the Scan
 To stop a scan that is currently running:
 ```
 curl -X PUT http://127.0.0.1:5000/fast_grid_scan/stop
+
 ```
+
+
+For running local dev logging
+------------------------------
+For development logs a local instance of graylog is needed. This needs to be run with both a mongo and elastic search instance.
+
+First, to build the configured graylog image, navigate to the graylog folder and run:
+
+```
+podman build . --format docker -t graylog:test
+```
+
+Then run the following commands in order:
+```
+podman run -d --net host --pod=graylog-pod --name=mongo mongo:4.2
+```
+```
+podman run -d --net host --pod=graylog-pod -e "http.host=0.0.0.0" -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" --name=elasticsearch docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
+```
+```
+podman run -d --net host --pod=graylog-pod -e GRAYLOG_HTTP_EXTERNAL_URI="http://localhost:9000/" -e GRAYLOG_MONGODB_URI="mongodb://localhost:27017/graylog" -e GRAYLOG_ELASTICSEARCH_HOSTS="http://localhost:9200/" --name=graylog localhost/graylog:test
+```
+where `localhost/graylog:test` is the name of the image you built.
+
+
+This uses the generic defaults for a local graylog instance. It can be accessed on `localhost:9000` where the username and password for the graylog portal are both admin.

--- a/README.md
+++ b/README.md
@@ -60,25 +60,6 @@ curl -X PUT http://127.0.0.1:5000/fast_grid_scan/stop
 
 For running local dev logging
 ------------------------------
-For development logs a local instance of graylog is needed. This needs to be run with both a mongo and elastic search instance.
-
-First, to build the configured graylog image, navigate to the graylog folder and run:
-
-```
-podman build . --format docker -t graylog:test
-```
-
-Then run the following commands in order:
-```
-podman run -d --net host --pod=graylog-pod --name=mongo mongo:4.2
-```
-```
-podman run -d --net host --pod=graylog-pod -e "http.host=0.0.0.0" -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" --name=elasticsearch docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
-```
-```
-podman run -d --net host --pod=graylog-pod -e GRAYLOG_HTTP_EXTERNAL_URI="http://localhost:9000/" -e GRAYLOG_MONGODB_URI="mongodb://localhost:27017/graylog" -e GRAYLOG_ELASTICSEARCH_HOSTS="http://localhost:9200/" --name=graylog localhost/graylog:test
-```
-where `localhost/graylog:test` is the name of the image you built.
-
+For development logs a local instance of graylog is needed. This needs to be run with both a mongo and elastic search instance. To set this up and run up the containers on your local machine run the `setup_graylog.sh` script.
 
 This uses the generic defaults for a local graylog instance. It can be accessed on `localhost:9000` where the username and password for the graylog portal are both admin.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,23 @@ You can start the bluesky runner by doing the following:
 ```
 pipenv run artemis
 ```
+The default behaviour of which is to run artemis with `INFO` level logging, sending its logs to both production graylog and to the beamline/log/bluesky/artemis.txt on the shared file system. 
+
+To run locally in a dev envrionment use
+```
+pipenv run artemis --dev
+```
+This will log to a local graylog instance instead and into a file at `./tmp/dev/artemis.txt`. A local instance of graylog will need to be running for this to work correctly. To set this up and run up the containers on your local machine run the `setup_graylog.sh` script.
+
+This uses the generic defaults for a local graylog instance. It can be accessed on `localhost:9000` where the username and password for the graylog portal are both admin.
+
+The logging level of artemis can be selected with the flag
+```
+pipenv run artemis --dev --logging-level DEBUG
+```
+
+**DO NOT** run artemis at DEBUG level on production (without the --dev flag). This will flood graylog with messages and make people very grumpy.
+
 
 Starting a scan
 --------------
@@ -56,16 +73,3 @@ To stop a scan that is currently running:
 curl -X PUT http://127.0.0.1:5003/fast_grid_scan/stop
 
 ```
-
-
-For running local dev logging
-------------------------------
-For development logs a local instance of graylog is needed. This needs to be run with both a mongo and elastic search instance. To set this up and run up the containers on your local machine run the `setup_graylog.sh` script.
-
-This uses the generic defaults for a local graylog instance. It can be accessed on `localhost:9000` where the username and password for the graylog portal are both admin. To run artemis in this mode use the `--dev` flag with the run command.
-
-You can also choose the logging level, like:
-```
-pipenv run artemis --dev --logging-level DEBUG
-```
-Without these flags the default behaviour will log to production graylog logs (not yet) with a logging level of INFO.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pipenv run artemis
 ```
 The default behaviour of which is to run artemis with `INFO` level logging, sending its logs to both production graylog and to the beamline/log/bluesky/artemis.txt on the shared file system. 
 
-To run locally in a dev envrionment use
+To run locally in a dev environment use
 ```
 pipenv run artemis --dev
 ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Starting a scan
 
 To start a scan you can do the following:
 ```
-curl -X PUT http://127.0.0.1:5003/fast_grid_scan/start --data-binary "@test_parameters.json" -H "Content-Type: application/json"
+curl -X PUT http://127.0.0.1:5000/fast_grid_scan/start --data-binary "@test_parameters.json" -H "Content-Type: application/json"
 ```
 
 Getting the Runner Status
@@ -62,7 +62,7 @@ Getting the Runner Status
 
 To get the status of the runner:
 ```
-curl http://127.0.0.1:5003/fast_grid_scan/status
+curl http://127.0.0.1:5000/fast_grid_scan/status
 ```
 
 Stopping the Scan
@@ -70,6 +70,11 @@ Stopping the Scan
 
 To stop a scan that is currently running:
 ```
-curl -X PUT http://127.0.0.1:5003/fast_grid_scan/stop
+curl -X PUT http://127.0.0.1:5000/fast_grid_scan/stop
 
 ```
+
+
+System tests
+============
+Currently to run against s03 the flask app port needs to be changed as the eiger control uses 5000 and this interferes (it also uses 5001 and 5002).

--- a/graylog/Dockerfile
+++ b/graylog/Dockerfile
@@ -1,4 +1,4 @@
-FROM graylog/graylog:4.3
+FROM graylog/graylog:4.2
 
 ENV GRAYLOG_ROOT_PASSWORD_SHA2 8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
 ENV GRAYLOG_PASSWORD_SECRET thisisasecretstring

--- a/graylog/Dockerfile
+++ b/graylog/Dockerfile
@@ -1,0 +1,10 @@
+FROM graylog/graylog:4.3
+
+ENV GRAYLOG_ROOT_PASSWORD_SHA2 8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918
+ENV GRAYLOG_PASSWORD_SECRET thisisasecretstring
+
+COPY tcp_input.json /usr/share/graylog/data/contentpacks/tcp_input.json
+
+ENV GRAYLOG_CONTENT_PACKS_LOADER_ENABLED true
+ENV GRAYLOG_CONTENT_PACKS_DIR data/contentpacks
+ENV GRAYLOG_CONTENT_PACKS_AUTO_INSTALL tcp_input.json

--- a/graylog/tcp_input.json
+++ b/graylog/tcp_input.json
@@ -8,7 +8,7 @@
     "vendor": "DLS",
     "url": "",
     "created_at": "2022-09-01T13:55:24.405Z",
-    "server_version": "4.3.5+32fa802",
+    "server_version": "4.2.13+9c90b93",
     "parameters": [],
     "entities": [
         {
@@ -95,7 +95,7 @@
             "constraints": [
                 {
                     "type": "server-version",
-                    "version": ">=4.3.5+32fa802"
+                    "version": ">=4.2.13+9c90b93"
                 }
             ]
         }

--- a/graylog/tcp_input.json
+++ b/graylog/tcp_input.json
@@ -1,0 +1,103 @@
+{
+    "id": "c7c601fc-5090-4a0c-a4f3-e757968eeca2",
+    "rev": 1,
+    "v": "1",
+    "name": "Artemis TCP Input",
+    "summary": "Artemis GELF TCP input.",
+    "description": "",
+    "vendor": "DLS",
+    "url": "",
+    "created_at": "2022-09-01T13:55:24.405Z",
+    "server_version": "4.3.5+32fa802",
+    "parameters": [],
+    "entities": [
+        {
+            "id": "82d25c14-574d-4f3e-be12-dd7e76e6ee03",
+            "type": {
+                "name": "input",
+                "version": "1"
+            },
+            "v": "1",
+            "data": {
+                "title": {
+                    "@type": "string",
+                    "@value": "Artemis GELF TCP"
+                },
+                "configuration": {
+                    "tls_key_file": {
+                        "@type": "string",
+                        "@value": ""
+                    },
+                    "port": {
+                        "@type": "integer",
+                        "@value": 5555
+                    },
+                    "tls_enable": {
+                        "@type": "boolean",
+                        "@value": false
+                    },
+                    "use_null_delimiter": {
+                        "@type": "boolean",
+                        "@value": true
+                    },
+                    "recv_buffer_size": {
+                        "@type": "integer",
+                        "@value": 1048576
+                    },
+                    "tcp_keepalive": {
+                        "@type": "boolean",
+                        "@value": false
+                    },
+                    "tls_client_auth_cert_file": {
+                        "@type": "string",
+                        "@value": ""
+                    },
+                    "bind_address": {
+                        "@type": "string",
+                        "@value": "127.0.0.1"
+                    },
+                    "tls_cert_file": {
+                        "@type": "string",
+                        "@value": ""
+                    },
+                    "max_message_size": {
+                        "@type": "integer",
+                        "@value": 2097152
+                    },
+                    "tls_client_auth": {
+                        "@type": "string",
+                        "@value": "disabled"
+                    },
+                    "decompress_size_limit": {
+                        "@type": "integer",
+                        "@value": 8388608
+                    },
+                    "number_worker_threads": {
+                        "@type": "integer",
+                        "@value": 2
+                    },
+                    "tls_key_password": {
+                        "@type": "string",
+                        "@value": ""
+                    }
+                },
+                "static_fields": {},
+                "type": {
+                    "@type": "string",
+                    "@value": "org.graylog2.inputs.gelf.tcp.GELFTCPInput"
+                },
+                "global": {
+                    "@type": "boolean",
+                    "@value": true
+                },
+                "extractors": []
+            },
+            "constraints": [
+                {
+                    "type": "server-version",
+                    "version": ">=4.3.5+32fa802"
+                }
+            ]
+        }
+    ]
+}

--- a/run_artemis.sh
+++ b/run_artemis.sh
@@ -142,7 +142,7 @@ if [[ $START == 1 ]]; then
 
     export ISPYB_CONFIG_PATH
 
-    pipenv run main &
+    pipenv run artemis &
 fi
 
 sleep 1

--- a/setup_graylog.sh
+++ b/setup_graylog.sh
@@ -2,6 +2,6 @@
 
 podman build ./graylog --format docker -t graylog:test
 
-podman run -d --net host --pod=graylog-pod --name=mongo mongo:4.2
-podman run -d --net host --pod=graylog-pod -e "http.host=0.0.0.0" -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" --name=elasticsearch docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
-podman run -d --net host --pod=graylog-pod -e GRAYLOG_HTTP_EXTERNAL_URI="http://localhost:9000/" -e GRAYLOG_MONGODB_URI="mongodb://localhost:27017/graylog" -e GRAYLOG_ELASTICSEARCH_HOSTS="http://localhost:9200/" --name=graylog localhost/graylog:test
+podman run -d --net host --pod=graylog-pod --name=artemis-mongo mongo:4.2
+podman run -d --net host --pod=graylog-pod -e "http.host=0.0.0.0" -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" --name=artemis-elasticsearch docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
+podman run -d --net host --pod=graylog-pod -e GRAYLOG_HTTP_EXTERNAL_URI="http://localhost:9000/" -e GRAYLOG_MONGODB_URI="mongodb://localhost:27017/graylog" -e GRAYLOG_ELASTICSEARCH_HOSTS="http://localhost:9200/" --name=artemis-graylog localhost/graylog:test

--- a/setup_graylog.sh
+++ b/setup_graylog.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+podman build ./graylog --format docker -t graylog:test
+
+podman run -d --net host --pod=graylog-pod --name=mongo mongo:4.2
+podman run -d --net host --pod=graylog-pod -e "http.host=0.0.0.0" -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" --name=elasticsearch docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
+podman run -d --net host --pod=graylog-pod -e GRAYLOG_HTTP_EXTERNAL_URI="http://localhost:9000/" -e GRAYLOG_MONGODB_URI="mongodb://localhost:27017/graylog" -e GRAYLOG_ELASTICSEARCH_HOSTS="http://localhost:9200/" --name=graylog localhost/graylog:test

--- a/setup_graylog.sh
+++ b/setup_graylog.sh
@@ -4,6 +4,6 @@ podman build ./graylog --format docker -t graylog:test
 
 podman pod create -n artemis-graylog-pod
 
-podman run -d --net host --pod=artemis-graylog-pod --name=mongo mongo:4.2
-podman run -d --net host --pod=artemis-graylog-pod -e "http.host=0.0.0.0" -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" --name=elasticsearch docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
-podman run -d --net host --pod=artemis-graylog-pod -e GRAYLOG_HTTP_EXTERNAL_URI="http://localhost:9000/" -e GRAYLOG_MONGODB_URI="mongodb://localhost:27017/graylog" -e GRAYLOG_ELASTICSEARCH_HOSTS="http://localhost:9200/" --name=graylog localhost/graylog:test
+podman run -d --net host --pod=artemis-graylog-pod --name=artemis-mongo mongo:4.2
+podman run -d --net host --pod=artemis-graylog-pod -e "http.host=0.0.0.0" -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" --name=artemis-elasticsearch docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
+podman run -d --net host --pod=artemis-graylog-pod -e GRAYLOG_HTTP_EXTERNAL_URI="http://localhost:9000/" -e GRAYLOG_MONGODB_URI="mongodb://localhost:27017/graylog" -e GRAYLOG_ELASTICSEARCH_HOSTS="http://localhost:9200/" --name=artemis-graylog localhost/graylog:test

--- a/setup_graylog.sh
+++ b/setup_graylog.sh
@@ -2,6 +2,8 @@
 
 podman build ./graylog --format docker -t graylog:test
 
-podman run -d --net host --pod=graylog-pod --name=artemis-mongo mongo:4.2
-podman run -d --net host --pod=graylog-pod -e "http.host=0.0.0.0" -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" --name=artemis-elasticsearch docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
-podman run -d --net host --pod=graylog-pod -e GRAYLOG_HTTP_EXTERNAL_URI="http://localhost:9000/" -e GRAYLOG_MONGODB_URI="mongodb://localhost:27017/graylog" -e GRAYLOG_ELASTICSEARCH_HOSTS="http://localhost:9200/" --name=artemis-graylog localhost/graylog:test
+podman pod create -n artemis-graylog-pod
+
+podman run -d --net host --pod=artemis-graylog-pod --name=mongo mongo:4.2
+podman run -d --net host --pod=artemis-graylog-pod -e "http.host=0.0.0.0" -e "discovery.type=single-node" -e "ES_JAVA_OPTS=-Xms512m -Xmx512m" --name=elasticsearch docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.0
+podman run -d --net host --pod=artemis-graylog-pod -e GRAYLOG_HTTP_EXTERNAL_URI="http://localhost:9000/" -e GRAYLOG_MONGODB_URI="mongodb://localhost:27017/graylog" -e GRAYLOG_ELASTICSEARCH_HOSTS="http://localhost:9200/" --name=graylog localhost/graylog:test

--- a/src/artemis/__main__.py
+++ b/src/artemis/__main__.py
@@ -163,7 +163,9 @@ if __name__ == "__main__":
         help="Choose overall logging level, defaults to INFO",
     )
     args = parser.parse_args()
-    artemis.log.set_up_logging(logging_level=args.logging_level, dev_mode=args.dev)
+    artemis.log.set_up_logging_handlers(
+        logging_level=args.logging_level, dev_mode=args.dev
+    )
     app, runner = create_app()
     atexit.register(runner.shutdown)
     flask_thread = threading.Thread(

--- a/src/artemis/__main__.py
+++ b/src/artemis/__main__.py
@@ -175,9 +175,7 @@ if __name__ == "__main__":
     app, runner = create_app()
     atexit.register(runner.shutdown)
     flask_thread = threading.Thread(
-        target=lambda: app.run(
-            host="0.0.0.0", port=5003, debug=True, use_reloader=False
-        ),
+        target=lambda: app.run(host="0.0.0.0", debug=True, use_reloader=False),
         daemon=True,
     )
     flask_thread.start()

--- a/src/artemis/__main__.py
+++ b/src/artemis/__main__.py
@@ -5,8 +5,7 @@ from dataclasses import dataclass
 from enum import Enum
 from json import JSONDecodeError
 from queue import Queue
-from sys import argv
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 from bluesky import RunEngine
 from dataclasses_json import dataclass_json

--- a/src/artemis/__main__.py
+++ b/src/artemis/__main__.py
@@ -164,14 +164,6 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
     artemis.log.set_up_logging(logging_level=args.logging_level, dev_mode=args.dev)
-
-    if not args.dev and args.logging_level == "DEBUG":
-        artemis.log.LOGGER.warning(
-            'Starting Artemis in DEBUG without "--dev" will flood production'
-            " graylog with messages. If you really need debug messages, maybe set up a"
-            " local graylog instead.\n"
-        )
-
     app, runner = create_app()
     atexit.register(runner.shutdown)
     flask_thread = threading.Thread(

--- a/src/artemis/__main__.py
+++ b/src/artemis/__main__.py
@@ -7,15 +7,43 @@ from json import JSONDecodeError
 from queue import Queue
 from typing import Optional, Tuple
 
+import graypy
 from bluesky import RunEngine
+from bluesky.log import config_bluesky_logging
+from bluesky.log import logger as bluesky_logger
 from dataclasses_json import dataclass_json
 from flask import Flask, request
 from flask_restful import Api, Resource
+from ophyd.log import config_ophyd_logging
+from ophyd.log import logger as ophyd_logger
 
 from artemis.fast_grid_scan_plan import get_plan
 from artemis.parameters import FullParameters
 
-logger = logging.getLogger(__name__)
+# log all messages to console, graylog and file,
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.DEBUG)
+formatter = logging.Formatter(
+    "%(asctime)s %(module)s %(name)s %(levelname)s: %(message)s"
+)
+# assign parenthood of ophyd bluesky loggers as artemis
+ophyd_logger.parent = LOGGER
+bluesky_logger.parent = LOGGER
+# Add additional seperate handles to the bluesky and ophyd loggers
+config_bluesky_logging(file="/tmp/bluesky.log", level="DEBUG")
+config_ophyd_logging(file="/tmp/ophyd.log", level="DEBUG")
+
+graylog_handler = graypy.GELFTCPHandler("localhost", 5555)
+graylog_handler.setFormatter(formatter)
+LOGGER.addHandler(graylog_handler)
+
+stream_handler = logging.StreamHandler()
+stream_handler.setFormatter(formatter)
+LOGGER.addHandler(stream_handler)
+
+file_handler = logging.FileHandler(filename="/tmp/artemis.log")
+file_handler.setFormatter(formatter)
+LOGGER.addHandler(file_handler)
 
 
 class Actions(Enum):
@@ -58,7 +86,7 @@ class BlueskyRunner:
         self.RE = RE
 
     def start(self, parameters: FullParameters) -> StatusAndMessage:
-        logger.info(f"Started with parameters: {parameters}")
+        LOGGER.info(f"Started with parameters: {parameters}")
         if (
             self.current_status.status == Status.BUSY.value
             or self.current_status.status == Status.ABORTING.value
@@ -99,7 +127,9 @@ class BlueskyRunner:
             command = self.command_queue.get()
             if command.action == Actions.START:
                 try:
-                    self.RE(get_plan(command.parameters))
+                    self.RE(
+                        get_plan(command.parameters)
+                    )  # time this, tag on sampleID in paramaters
                     self.current_status = StatusAndMessage(Status.IDLE)
                     self.last_run_aborted = False
                 except Exception as exception:
@@ -153,7 +183,9 @@ if __name__ == "__main__":
     app, runner = create_app()
     atexit.register(runner.shutdown)
     flask_thread = threading.Thread(
-        target=lambda: app.run(host="0.0.0.0", debug=True, use_reloader=False),
+        target=lambda: app.run(
+            host="0.0.0.0", port=5003, debug=True, use_reloader=False
+        ),
         daemon=True,
     )
     flask_thread.start()

--- a/src/artemis/__main__.py
+++ b/src/artemis/__main__.py
@@ -167,6 +167,13 @@ if __name__ == "__main__":
     args = parser.parse_args()
     artemis.log.set_up_logging(logging_level=args.logging_level, dev_mode=args.dev)
 
+    if not args.dev and args.logging_level == "DEBUG":
+        artemis.log.LOGGER.warning(
+            'Starting Artemis in DEBUG without "--dev" will flood production'
+            " graylog with messages. If you really need debug messages, maybe set up a"
+            " local graylog instead.\n"
+        )
+
     app, runner = create_app()
     atexit.register(runner.shutdown)
     flask_thread = threading.Thread(

--- a/src/artemis/__main__.py
+++ b/src/artemis/__main__.py
@@ -148,8 +148,7 @@ def create_app(
     return app, runner
 
 
-if __name__ == "__main__":
-
+def cli_args() -> Tuple[Optional[bool], Optional[str]]:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--dev",
@@ -163,9 +162,12 @@ if __name__ == "__main__":
         help="Choose overall logging level, defaults to INFO",
     )
     args = parser.parse_args()
-    artemis.log.set_up_logging_handlers(
-        logging_level=args.logging_level, dev_mode=args.dev
-    )
+    return args.logging_level, args.dev
+
+
+if __name__ == "__main__":
+    args = cli_args()
+    artemis.log.set_up_logging_handlers(*args)
     app, runner = create_app()
     atexit.register(runner.shutdown)
     flask_thread = threading.Thread(

--- a/src/artemis/__main__.py
+++ b/src/artemis/__main__.py
@@ -98,9 +98,7 @@ class BlueskyRunner:
             command = self.command_queue.get()
             if command.action == Actions.START:
                 try:
-                    self.RE(
-                        get_plan(command.parameters)
-                    )  # time this, tag on sampleID in paramaters
+                    self.RE(get_plan(command.parameters))
                     self.current_status = StatusAndMessage(Status.IDLE)
                     self.last_run_aborted = False
                 except Exception as exception:

--- a/src/artemis/__main__.py
+++ b/src/artemis/__main__.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass
 from enum import Enum
 from json import JSONDecodeError
 from queue import Queue
-from typing import Optional, Tuple
+from sys import argv
+from typing import List, Optional, Tuple
 
 from bluesky import RunEngine
 from dataclasses_json import dataclass_json
@@ -148,7 +149,7 @@ def create_app(
     return app, runner
 
 
-def cli_args() -> Tuple[Optional[bool], Optional[str]]:
+def cli_arg_parse() -> Tuple[Optional[bool], Optional[str]]:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--dev",
@@ -166,7 +167,7 @@ def cli_args() -> Tuple[Optional[bool], Optional[str]]:
 
 
 if __name__ == "__main__":
-    args = cli_args()
+    args = cli_arg_parse()
     artemis.log.set_up_logging_handlers(*args)
     app, runner = create_app()
     atexit.register(runner.shutdown)

--- a/src/artemis/fast_grid_scan_plan.py
+++ b/src/artemis/fast_grid_scan_plan.py
@@ -4,9 +4,7 @@ import os
 import bluesky.plan_stubs as bps
 import bluesky.preprocessors as bpp
 from bluesky import RunEngine
-from bluesky.log import config_bluesky_logging
 from bluesky.utils import ProgressBarManager
-from ophyd.log import config_ophyd_logging
 
 from artemis.devices.eiger import EigerDetector
 from artemis.devices.fast_grid_scan import set_fast_grid_scan_params
@@ -18,9 +16,6 @@ from artemis.ispyb.store_in_ispyb import StoreInIspyb2D, StoreInIspyb3D
 from artemis.nexus_writing.write_nexus import NexusWriter
 from artemis.parameters import SIM_BEAMLINE, FullParameters
 from artemis.zocalo_interaction import run_end, run_start, wait_for_result
-
-config_bluesky_logging(file="/tmp/bluesky.log", level="DEBUG")
-config_ophyd_logging(file="/tmp/ophyd.log", level="DEBUG")
 
 # Tolerance for how close omega must start to 0
 OMEGA_TOLERANCE = 0.1

--- a/src/artemis/log.py
+++ b/src/artemis/log.py
@@ -28,12 +28,12 @@ def set_up_logging(
     formatter = logging.Formatter(
         "[%(asctime)s] %(name)s %(module)s %(levelname)s: %(message)s"
     )
-    handlers: dict[str, logging.Handler] = {
-        "graylog": GELFTCPHandler(graylog_host, graylog_port),
-        "stream": logging.StreamHandler(),
-        "file": logging.FileHandler(filename=file_path),
-    }
-    for handler in handlers.values():
+    handlers: list[logging.Handler] = [
+        GELFTCPHandler(graylog_host, graylog_port),
+        logging.StreamHandler(),
+        logging.FileHandler(filename=file_path),
+    ]
+    for handler in handlers:
         handler.setFormatter(formatter)
         handler.setLevel(logging_level)
         LOGGER.addHandler(handler)

--- a/src/artemis/log.py
+++ b/src/artemis/log.py
@@ -24,9 +24,8 @@ def set_up_logging(logging_level: Union[str, None], dev_mode: bool) -> None:
     file_path = Path(_get_logging_file_path(), "artemis.log")
     graylog_host, graylog_port = _get_graylog_configuration(dev_mode)
     formatter = logging.Formatter(
-        "%(asctime)s %(module)s %(name)s %(levelname)s: %(message)s"
+        "[%(asctime)s] %(name)s %(module)s %(levelname)s: %(message)s"
     )
-
     handlers: dict[str, logging.Handler] = {
         "graylog": graypy.GELFTCPHandler(graylog_host, graylog_port),
         "stream": logging.StreamHandler(),
@@ -56,7 +55,6 @@ def _get_graylog_configuration(dev_mode: bool) -> tuple[str, int]:
         host = "localhost"
         port = 5555
     else:
-        # find the real values for these
         host = "localhost"
         port = 12201
 
@@ -77,6 +75,7 @@ def _get_logging_file_path() -> Path:
     logging_path: Path
 
     if beamline:
+        # to do: make this beamline path the one on dls_sw
         logging_path = Path("./tmp/" + beamline + "/")
     else:
         logging_path = Path("./tmp/dev/")

--- a/src/artemis/log.py
+++ b/src/artemis/log.py
@@ -1,7 +1,7 @@
 import logging
 from os import environ
 from pathlib import Path
-from typing import Union
+from typing import Tuple, Union
 
 import graypy
 from bluesky.log import config_bluesky_logging
@@ -43,7 +43,7 @@ def set_up_logging(logging_level: Union[str, None], dev_mode: bool) -> None:
         )
 
 
-def _get_graylog_configuration(dev_mode: bool) -> tuple[str, int]:
+def _get_graylog_configuration(dev_mode: bool) -> Tuple[str, int]:
     """Get the host and port for the  graylog interaction.
 
     If running on dev mode, this switches to localhost. Otherwise it publishes to the

--- a/src/artemis/log.py
+++ b/src/artemis/log.py
@@ -15,9 +15,9 @@ ophyd_logger.parent = LOGGER
 bluesky_logger.parent = LOGGER
 
 
-def set_up_logging(
+def set_up_logging_handlers(
     logging_level: Union[str, None] = "INFO", dev_mode: bool = False
-) -> None:
+) -> list[logging.Handler]:
     """Set up the logging level and instances for user chosen level of logging.
 
     Mode defaults to production and can be switched to dev with the --dev flag on run.
@@ -51,6 +51,8 @@ def set_up_logging(
             " WITH MESSAGES. If you really need debug messages, set up a"
             " local graylog instead!\n"
         )
+
+    return handlers
 
 
 def _get_graylog_configuration(dev_mode: bool) -> Tuple[str, int]:

--- a/src/artemis/log.py
+++ b/src/artemis/log.py
@@ -44,6 +44,14 @@ def set_up_logging(
             logging_level=logging_level, logging_path=_get_logging_file_path()
         )
 
+    # Warn users if trying to run in prod in debug mode
+    if not dev_mode and logging_level == "DEBUG":
+        LOGGER.warning(
+            'STARTING ARTEMIS IN DEBUG WITHOUT "--dev" WILL FLOOD PRODUCTION GRAYLOG'
+            " WITH MESSAGES. If you really need debug messages, set up a"
+            " local graylog instead!\n"
+        )
+
 
 def _get_graylog_configuration(dev_mode: bool) -> Tuple[str, int]:
     """Get the host and port for the  graylog interaction.

--- a/src/artemis/log.py
+++ b/src/artemis/log.py
@@ -3,9 +3,9 @@ from os import environ
 from pathlib import Path
 from typing import Tuple, Union
 
-import graypy
 from bluesky.log import config_bluesky_logging
 from bluesky.log import logger as bluesky_logger
+from graypy import GELFTCPHandler
 from ophyd.log import config_ophyd_logging
 from ophyd.log import logger as ophyd_logger
 
@@ -27,7 +27,7 @@ def set_up_logging(logging_level: Union[str, None], dev_mode: bool) -> None:
         "[%(asctime)s] %(name)s %(module)s %(levelname)s: %(message)s"
     )
     handlers: dict[str, logging.Handler] = {
-        "graylog": graypy.GELFTCPHandler(graylog_host, graylog_port),
+        "graylog": GELFTCPHandler(graylog_host, graylog_port),
         "stream": logging.StreamHandler(),
         "file": logging.FileHandler(filename=file_path),
     }

--- a/src/artemis/log.py
+++ b/src/artemis/log.py
@@ -15,14 +15,11 @@ ophyd_logger.parent = LOGGER
 bluesky_logger.parent = LOGGER
 
 
-def set_up_logging(
-    logging_level: Union[str, None] = "INFO", dev_mode: bool = False
-) -> None:
+def set_up_logging(logging_level: str = "INFO", dev_mode: bool = False) -> None:
     """Set up the logging level and instances for user chosen level of logging.
 
     Mode defaults to production and can be switched to dev with the --dev flag on run.
     """
-    logging_level = "INFO" if logging_level is None else logging_level
     file_path = Path(_get_logging_file_path(), "artemis.txt")
     graylog_host, graylog_port = _get_graylog_configuration(dev_mode)
     formatter = logging.Formatter(

--- a/src/artemis/log.py
+++ b/src/artemis/log.py
@@ -15,11 +15,14 @@ ophyd_logger.parent = LOGGER
 bluesky_logger.parent = LOGGER
 
 
-def set_up_logging(logging_level: str = "INFO", dev_mode: bool = False) -> None:
+def set_up_logging(
+    logging_level: Union[str, None] = "INFO", dev_mode: bool = False
+) -> None:
     """Set up the logging level and instances for user chosen level of logging.
 
     Mode defaults to production and can be switched to dev with the --dev flag on run.
     """
+    logging_level = logging_level if logging_level else "INFO"
     file_path = Path(_get_logging_file_path(), "artemis.txt")
     graylog_host, graylog_port = _get_graylog_configuration(dev_mode)
     formatter = logging.Formatter(

--- a/src/artemis/log.py
+++ b/src/artemis/log.py
@@ -1,7 +1,7 @@
 import logging
 from os import environ
 from pathlib import Path
-from typing import Tuple, Union
+from typing import List, Tuple, Union
 
 from bluesky.log import config_bluesky_logging
 from bluesky.log import logger as bluesky_logger
@@ -17,7 +17,7 @@ bluesky_logger.parent = LOGGER
 
 def set_up_logging_handlers(
     logging_level: Union[str, None] = "INFO", dev_mode: bool = False
-) -> list[logging.Handler]:
+) -> List[logging.Handler]:
     """Set up the logging level and instances for user chosen level of logging.
 
     Mode defaults to production and can be switched to dev with the --dev flag on run.

--- a/src/artemis/log.py
+++ b/src/artemis/log.py
@@ -15,7 +15,9 @@ ophyd_logger.parent = LOGGER
 bluesky_logger.parent = LOGGER
 
 
-def set_up_logging(logging_level: Union[str, None], dev_mode: bool) -> None:
+def set_up_logging(
+    logging_level: Union[str, None] = "INFO", dev_mode: bool = False
+) -> None:
     """Set up the logging level and instances for user chosen level of logging.
 
     Mode defaults to production and can be switched to dev with the --dev flag on run.

--- a/src/artemis/log.py
+++ b/src/artemis/log.py
@@ -1,0 +1,98 @@
+import logging
+from os import environ
+from pathlib import Path
+from typing import Union
+
+import graypy
+from bluesky.log import config_bluesky_logging
+from bluesky.log import logger as bluesky_logger
+from ophyd.log import config_ophyd_logging
+from ophyd.log import logger as ophyd_logger
+
+LOGGER = logging.getLogger("Artemis")
+LOGGER.setLevel(logging.DEBUG)  # default logger to log everything
+ophyd_logger.parent = LOGGER
+bluesky_logger.parent = LOGGER
+
+
+def set_up_logging(logging_level: Union[str, None], dev_mode: bool) -> None:
+    """Set up the logging level and instances for user chosen level of logging.
+
+    Mode defaults to production and can be switched to dev with the --dev flag on run.
+    """
+    logging_level = "INFO" if logging_level is None else logging_level
+    file_path = Path(_get_logging_file_path(), "artemis.log")
+    graylog_host, graylog_port = _get_graylog_configuration(dev_mode)
+    formatter = logging.Formatter(
+        "%(asctime)s %(module)s %(name)s %(levelname)s: %(message)s"
+    )
+
+    handlers: dict[str, logging.Handler] = {
+        "graylog": graypy.GELFTCPHandler(graylog_host, graylog_port),
+        "stream": logging.StreamHandler(),
+        "file": logging.FileHandler(filename=file_path),
+    }
+    for handler in handlers.values():
+        handler.setFormatter(formatter)
+        handler.setLevel(logging_level)
+        LOGGER.addHandler(handler)
+
+    # for dev
+    set_seperate_ophyd_bluesky_files(
+        logging_level=logging_level, logging_path=_get_logging_file_path()
+    )
+
+
+def _get_graylog_configuration(dev_mode: bool) -> tuple[str, int]:
+    """Get the host and port for the  graylog interaction.
+
+    If running on dev mode, this switches to localhost. Otherwise it publishes to the
+    dls graylog.
+
+    Returns:
+        (host,port): A tuple of the relevent host and port for graylog.
+    """
+    if dev_mode:
+        host = "localhost"
+        port = 5555
+    else:
+        # find the real values for these
+        host = "localhost"
+        port = 12201
+
+    return host, port
+
+
+def _get_logging_file_path() -> Path:
+    """Get the path to write the artemis log files to.
+
+    If on a beamline, this will be written to the according area depending on the
+    BEAMLINE envrionment variable. If no envrionment variable is found it will default
+    it to the tmp/dev directory.
+
+    Returns:
+        logging_path (Path): Path to the log file for the file handler to write to.
+    """
+    beamline: Union[str, None] = environ.get("BEAMLINE")
+    logging_path: Path
+
+    if beamline:
+        logging_path = Path("./tmp/" + beamline + "/")
+    else:
+        logging_path = Path("./tmp/dev/")
+    Path(logging_path).mkdir(parents=True, exist_ok=True)
+
+    return logging_path
+
+
+def set_seperate_ophyd_bluesky_files(logging_level: str, logging_path: Path) -> None:
+    """Set file path for the file handlder to the individual Bluesky and Ophyd loggers.
+
+    These provide seperate, nicely formatted logs in the same dir as the artemis log
+    file for each individual module.
+    """
+    bluesky_file_path: Path = Path(logging_path, "bluesky.log")
+    ophyd_file_path: Path = Path(logging_path, "ophyd.log")
+
+    config_bluesky_logging(file=str(bluesky_file_path), level=logging_level)
+    config_ophyd_logging(file=str(ophyd_file_path), level=logging_level)

--- a/src/artemis/log.py
+++ b/src/artemis/log.py
@@ -21,7 +21,7 @@ def set_up_logging(logging_level: Union[str, None], dev_mode: bool) -> None:
     Mode defaults to production and can be switched to dev with the --dev flag on run.
     """
     logging_level = "INFO" if logging_level is None else logging_level
-    file_path = Path(_get_logging_file_path(), "artemis.log")
+    file_path = Path(_get_logging_file_path(), "artemis.txt")
     graylog_host, graylog_port = _get_graylog_configuration(dev_mode)
     formatter = logging.Formatter(
         "[%(asctime)s] %(name)s %(module)s %(levelname)s: %(message)s"
@@ -36,10 +36,11 @@ def set_up_logging(logging_level: Union[str, None], dev_mode: bool) -> None:
         handler.setLevel(logging_level)
         LOGGER.addHandler(handler)
 
-    # for dev
-    set_seperate_ophyd_bluesky_files(
-        logging_level=logging_level, logging_path=_get_logging_file_path()
-    )
+    # for assistance in debugging
+    if dev_mode:
+        set_seperate_ophyd_bluesky_files(
+            logging_level=logging_level, logging_path=_get_logging_file_path()
+        )
 
 
 def _get_graylog_configuration(dev_mode: bool) -> tuple[str, int]:
@@ -55,8 +56,8 @@ def _get_graylog_configuration(dev_mode: bool) -> tuple[str, int]:
         host = "localhost"
         port = 5555
     else:
-        host = "localhost"
-        port = 12201
+        host = "graylog2.diamond.ac.uk"
+        port = 12218
 
     return host, port
 
@@ -75,11 +76,10 @@ def _get_logging_file_path() -> Path:
     logging_path: Path
 
     if beamline:
-        # to do: make this beamline path the one on dls_sw
-        logging_path = Path("./tmp/" + beamline + "/")
+        logging_path = Path("/dls_sw/" + beamline + "/logs/bluesky/")
     else:
         logging_path = Path("./tmp/dev/")
-    Path(logging_path).mkdir(parents=True, exist_ok=True)
+        Path(logging_path).mkdir(parents=True, exist_ok=True)
 
     return logging_path
 

--- a/src/artemis/log.py
+++ b/src/artemis/log.py
@@ -53,13 +53,9 @@ def _get_graylog_configuration(dev_mode: bool) -> Tuple[str, int]:
         (host,port): A tuple of the relevent host and port for graylog.
     """
     if dev_mode:
-        host = "localhost"
-        port = 5555
+        return "localhost", 5555
     else:
-        host = "graylog2.diamond.ac.uk"
-        port = 12218
-
-    return host, port
+        return "graylog2.diamond.ac.uk", 12218
 
 
 def _get_logging_file_path() -> Path:

--- a/src/artemis/tests/test_log.py
+++ b/src/artemis/tests/test_log.py
@@ -1,48 +1,60 @@
-import os
+import logging
+from importlib import reload
+from os import environ
 from pathlib import Path
 from unittest.mock import patch
 
-from artemis.log import LOGGER, set_up_logging
+import pytest
+
+from artemis import log
 
 
-@patch("artemis.log.graypy")
+@pytest.fixture(autouse=True, scope="module")
+def cleanup_logger():
+    yield
+    reload(logging)
+    reload(log)
+
+
+@patch("artemis.log.GELFTCPHandler")
 @patch("artemis.log.logging")
 def test_handlers_set_at_correct_debug_level(mock_logging, mock_graypy):
-    set_up_logging(None, False)
-    handlers = LOGGER.handlers
+    log.set_up_logging(None, False)
+    handlers = log.LOGGER.handlers
     assert len(handlers) == 3
     for handler in handlers:
         handler.setLevel.assert_called_once_with("INFO")
 
 
-@patch("artemis.log.graypy")
+@patch("artemis.log.GELFTCPHandler")
 @patch("artemis.log.logging")
-def test_dev_mode_sets_correct_graypy_handler(mock_logging, mock_graypy):
-    set_up_logging(None, True)
-    mock_graypy.GELFTCPHandler.assert_called_once_with("localhost", 5555)
+def test_dev_mode_sets_correct_graypy_handler(mock_logging, mock_GELFTCPHandler):
+    log.set_up_logging(None, True)
+    mock_GELFTCPHandler.assert_called_once_with("localhost", 5555)
+    pass
 
 
-@patch("artemis.log.graypy")
+@patch("artemis.log.GELFTCPHandler")
 @patch("artemis.log.logging")
-def test_prod_mode_sets_correct_graypy_handler(mock_logging, mock_graypy):
-    set_up_logging(None, False)
-    mock_graypy.GELFTCPHandler.assert_called_once_with("graylog2.diamond.ac.uk", 12218)
+def test_prod_mode_sets_correct_graypy_handler(mock_logging, mock_GELFTCPHandler):
+    log.set_up_logging(None, False)
+    mock_GELFTCPHandler.assert_called_once_with("graylog2.diamond.ac.uk", 12218)
 
 
-@patch("artemis.log.graypy")
+@patch("artemis.log.GELFTCPHandler")
 @patch("artemis.log.logging")
-def test_dev_mode_sets_correct_file_handler(mock_logging, mock_graypy):
-    set_up_logging(None, True)
+def test_dev_mode_sets_correct_file_handler(mock_logging, mock_GELFTCPHandler):
+    log.set_up_logging(None, True)
     mock_logging.FileHandler.assert_called_once_with(
         filename=Path("./tmp/dev/artemis.txt")
     )
 
 
-@patch("artemis.log.graypy")
+@patch("artemis.log.GELFTCPHandler")
 @patch("artemis.log.logging")
-@patch.dict(os.environ, {"BEAMLINE": "S03"})
-def test_prod_mode_sets_correct_file_handler(mock_logging, mock_graypy):
-    set_up_logging(None, False)
+@patch.dict(environ, {"BEAMLINE": "S03"})
+def test_prod_mode_sets_correct_file_handler(mock_logging, mock_GELFTCPHandler):
+    log.set_up_logging(None, False)
     mock_logging.FileHandler.assert_called_once_with(
         filename=Path("/dls_sw/S03/logs/bluesky/artemis.txt")
     )

--- a/src/artemis/tests/test_log.py
+++ b/src/artemis/tests/test_log.py
@@ -1,0 +1,48 @@
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+from artemis.log import LOGGER, set_up_logging
+
+
+@patch("artemis.log.graypy")
+@patch("artemis.log.logging")
+def test_handlers_set_at_correct_debug_level(mock_logging, mock_graypy):
+    set_up_logging(None, False)
+    handlers = LOGGER.handlers
+    assert len(handlers) == 3
+    for handler in handlers:
+        handler.setLevel.assert_called_once_with("INFO")
+
+
+@patch("artemis.log.graypy")
+@patch("artemis.log.logging")
+def test_dev_mode_sets_correct_graypy_handler(mock_logging, mock_graypy):
+    set_up_logging(None, True)
+    mock_graypy.GELFTCPHandler.assert_called_once_with("localhost", 5555)
+
+
+@patch("artemis.log.graypy")
+@patch("artemis.log.logging")
+def test_prod_mode_sets_correct_graypy_handler(mock_logging, mock_graypy):
+    set_up_logging(None, False)
+    mock_graypy.GELFTCPHandler.assert_called_once_with("graylog2.diamond.ac.uk", 12218)
+
+
+@patch("artemis.log.graypy")
+@patch("artemis.log.logging")
+def test_dev_mode_sets_correct_file_handler(mock_logging, mock_graypy):
+    set_up_logging(None, True)
+    mock_logging.FileHandler.assert_called_once_with(
+        filename=Path("./tmp/dev/artemis.txt")
+    )
+
+
+@patch("artemis.log.graypy")
+@patch("artemis.log.logging")
+@patch.dict(os.environ, {"BEAMLINE": "S03"})
+def test_prod_mode_sets_correct_file_handler(mock_logging, mock_graypy):
+    set_up_logging(None, False)
+    mock_logging.FileHandler.assert_called_once_with(
+        filename=Path("/dls_sw/S03/logs/bluesky/artemis.txt")
+    )

--- a/src/artemis/tests/test_log.py
+++ b/src/artemis/tests/test_log.py
@@ -1,50 +1,76 @@
-import logging
-from importlib import reload
 from os import environ
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from artemis import log
 
 
-@pytest.fixture(autouse=True, scope="module")
-def cleanup_logger():
-    yield
-    reload(logging)
-    reload(log)
+@pytest.fixture()
+def mock_logger():
+    with patch("artemis.log.LOGGER") as mock_LOGGER:
+        yield mock_LOGGER
 
 
 @patch("artemis.log.GELFTCPHandler")
 @patch("artemis.log.logging")
-def test_handlers_set_at_correct_debug_level(mock_logging, mock_graypy):
-    log.set_up_logging(None, False)
-    handlers = log.LOGGER.handlers
-    assert len(handlers) == 3
+def test_handlers_set_at_correct_default_level(
+    mock_logging,
+    mock_GELFTCPHandler,
+    mock_logger: MagicMock,
+):
+    handlers = log.set_up_logging_handlers(None, False)
+
     for handler in handlers:
+        mock_logger.addHandler.assert_any_call(handler)
         handler.setLevel.assert_called_once_with("INFO")
 
 
 @patch("artemis.log.GELFTCPHandler")
 @patch("artemis.log.logging")
-def test_dev_mode_sets_correct_graypy_handler(mock_logging, mock_GELFTCPHandler):
-    log.set_up_logging(None, True)
-    mock_GELFTCPHandler.assert_called_once_with("localhost", 5555)
-    pass
+def test_handlers_set_at_correct_debug_level(
+    mock_logging,
+    mock_GELFTCPHandler,
+    mock_logger: MagicMock,
+):
+    handlers = log.set_up_logging_handlers("DEBUG", True)
+
+    for handler in handlers:
+        mock_logger.addHandler.assert_any_call(handler)
+        handler.setLevel.assert_called_once_with("DEBUG")
 
 
 @patch("artemis.log.GELFTCPHandler")
 @patch("artemis.log.logging")
-def test_prod_mode_sets_correct_graypy_handler(mock_logging, mock_GELFTCPHandler):
-    log.set_up_logging(None, False)
+def test_dev_mode_sets_correct_graypy_handler(
+    mock_logging,
+    mock_GELFTCPHandler,
+    mock_logger: MagicMock,
+):
+    log.set_up_logging_handlers(None, True)
+    mock_GELFTCPHandler.assert_called_once_with("localhost", 5555)
+
+
+@patch("artemis.log.GELFTCPHandler")
+@patch("artemis.log.logging")
+def test_prod_mode_sets_correct_graypy_handler(
+    mock_logging,
+    mock_GELFTCPHandler,
+    mock_logger: MagicMock,
+):
+    log.set_up_logging_handlers(None, False)
     mock_GELFTCPHandler.assert_called_once_with("graylog2.diamond.ac.uk", 12218)
 
 
 @patch("artemis.log.GELFTCPHandler")
 @patch("artemis.log.logging")
-def test_dev_mode_sets_correct_file_handler(mock_logging, mock_GELFTCPHandler):
-    log.set_up_logging(None, True)
+def test_dev_mode_sets_correct_file_handler(
+    mock_logging,
+    mock_GELFTCPHandler,
+    mock_logger: MagicMock,
+):
+    log.set_up_logging_handlers(None, True)
     mock_logging.FileHandler.assert_called_once_with(
         filename=Path("./tmp/dev/artemis.txt")
     )
@@ -53,8 +79,28 @@ def test_dev_mode_sets_correct_file_handler(mock_logging, mock_GELFTCPHandler):
 @patch("artemis.log.GELFTCPHandler")
 @patch("artemis.log.logging")
 @patch.dict(environ, {"BEAMLINE": "S03"})
-def test_prod_mode_sets_correct_file_handler(mock_logging, mock_GELFTCPHandler):
-    log.set_up_logging(None, False)
+def test_prod_mode_sets_correct_file_handler(
+    mock_logging,
+    mock_GELFTCPHandler,
+    mock_logger: MagicMock,
+):
+    log.set_up_logging_handlers(None, False)
     mock_logging.FileHandler.assert_called_once_with(
         filename=Path("/dls_sw/S03/logs/bluesky/artemis.txt")
     )
+
+
+@patch("artemis.log.GELFTCPHandler")
+@patch("artemis.log.logging")
+def test_setting_debug_in_prod_gives_warning(
+    mock_logging,
+    mock_GELFTCPHandler,
+    mock_logger: MagicMock,
+):
+    warning_string = (
+        'STARTING ARTEMIS IN DEBUG WITHOUT "--dev" WILL FLOOD PRODUCTION '
+        "GRAYLOG WITH MESSAGES. If you really need debug messages, set up a local "
+        "graylog instead!\n"
+    )
+    log.set_up_logging_handlers("DEBUG", False)
+    mock_logger.warning.assert_any_call(warning_string)

--- a/src/artemis/tests/test_main_system.py
+++ b/src/artemis/tests/test_main_system.py
@@ -1,6 +1,7 @@
 import json
 import threading
 from dataclasses import dataclass
+from sys import argv
 from time import sleep
 from typing import Any, Callable
 from unittest.mock import patch
@@ -8,7 +9,7 @@ from unittest.mock import patch
 import pytest
 from flask.testing import FlaskClient
 
-from artemis.__main__ import Actions, Status, create_app
+from artemis.__main__ import Actions, Status, cli_arg_parse, create_app
 from artemis.parameters import FullParameters
 
 FGS_ENDPOINT = "/fast_grid_scan/"
@@ -170,3 +171,9 @@ def test_start_with_json_file_gives_success(test_env: ClientAndRunEngine):
         test_parameters_json = test_parameters_file.read()
     response = test_env.client.put(START_ENDPOINT, data=test_parameters_json)
     check_status_in_response(response, Status.SUCCESS)
+
+
+def test_cli_args_parse():
+    argv[1:] = ["--dev", "--logging-level=DEBUG"]
+    test_args = cli_arg_parse()
+    assert test_args == ("DEBUG", True)


### PR DESCRIPTION
Fixes #27 

This should do the required changes of logging to graylog and into the correct beamline areas.

Along with this I have set up an input on the dls graylog called Artemis, and a stream called Artemis(MX DAQ). Currently the stream just accepts any messages in it from that input, but can be made more sophisticated as more things get added.

Before this is merged I'd like a better overview on what the Artemis Zocalo config is doing with regards to logging. It is no longer sending them to the MX analysis graylog stream thanks to Richards fix, however i'd like to configure it so they end up in the Artemis(MX DAQ) stream.