### PR TITLE
WIP: Beam topup plan attempt

### DIFF
--- a/src/artemis/beam_topup_plan.py
+++ b/src/artemis/beam_topup_plan.py
@@ -1,0 +1,111 @@
+import time
+from dataclasses import dataclass
+
+from bluesky import RunEngine
+from bluesky.plan_stubs import null
+from bluesky.suspenders import SuspendBoolHigh
+from ophyd import Component, Device, Signal
+
+from artemis.devices.synchrotron import Synchrotron
+
+
+@dataclass
+class TopupPlanParameters:
+    instability_time: float
+    threshold_percentage: float
+    total_exposure_time: float
+
+
+class SynchrotronMonitor(Device):
+
+    synchrotron: Synchrotron = Component(Synchrotron)
+    total_exposure_time_signal: Signal = Component(Signal, value=1)
+    # Seconds of estimated beam instability following topup:
+    time_beam_unstable_signal: Signal = Component(Signal)
+    threshold_percentage_signal: Signal = Component(Signal)
+    topup_gate_signal: Signal = Component(Signal, value=False)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.synchrotron.top_up.topup_end_countdown.subscribe(
+            self.set_topup_gate_signal
+        )
+
+    def set_topup_gate_signal(self, *_, **__):
+        self.topup_gate_signal.put(self.get_topup_gate())
+
+    def get_topup_gate(self):
+        total_exposure_time = self.total_exposure_time_signal.get()
+        time_to_topup = self.synchrotron.top_up.topup_start_countdown.get()
+        mode_precludes_gating = self._mode_precludes_gating(time_to_topup)
+        sufficient_time_before_topup = self._sufficient_time_before_topup(
+            time_to_topup, total_exposure_time
+        )
+        time_beam_unstable = self.time_beam_unstable_signal.get()
+        threshold_percentage = self.threshold_percentage_signal.get()
+        topup_degrades_exposure = self._topup_degrades_exposure(
+            total_exposure_time, time_beam_unstable, threshold_percentage
+        )
+        delay_required = (
+            not (mode_precludes_gating or sufficient_time_before_topup)
+            and topup_degrades_exposure
+        )
+        return delay_required
+
+    @staticmethod
+    def _topup_degrades_exposure(
+        total_exposure_time, time_beam_unstable, threshold_percentage
+    ):
+        # return True if topup duration eats a significant fraction of planned exposure time
+        return 100.0 * time_beam_unstable / total_exposure_time > threshold_percentage
+
+    def _mode_precludes_gating(self, time_to_topup):
+        return (
+            self._in_decay_mode(time_to_topup)
+            or not self._gating_permitted_in_machine_mode()
+        )
+
+    def _gating_permitted_in_machine_mode(self):
+        machine_mode = self.synchrotron.machine_status.synchrotron_mode.get()
+        permitted_modes = ("User", "Special")
+        return machine_mode in permitted_modes
+
+    @staticmethod
+    def _in_decay_mode(time_to_topup):
+        # If this is -1 we're in decay mode so no need to gate as no topup
+        return time_to_topup == -1
+
+    @staticmethod
+    def _sufficient_time_before_topup(time_to_topup, total_exposure_time):
+        return time_to_topup > total_exposure_time
+
+
+def plan(
+    synchrotron_monitor: SynchrotronMonitor, topup_monitor_args: TopupPlanParameters
+):
+    synchrotron_monitor.wait_for_connection()
+    synchrotron_monitor.total_exposure_time_signal.put(
+        topup_monitor_args.total_exposure_time
+    )
+    synchrotron_monitor.time_beam_unstable_signal.put(
+        topup_monitor_args.instability_time
+    )
+    synchrotron_monitor.threshold_percentage_signal.put(
+        topup_monitor_args.threshold_percentage
+    )
+    for i in range(400):
+        time.sleep(1)
+        yield from null()
+        print("Plan is running:", i)  # , synchrotron_monitor.topup_gate_signal.get())
+
+
+if __name__ == "__main__":
+    RE = RunEngine()
+    synchrotron_monitor = SynchrotronMonitor(name="monitor")
+    synchrotron_monitor.wait_for_connection()
+    sus = SuspendBoolHigh(synchrotron_monitor.topup_gate_signal)
+    RE.install_suspender(sus)
+    topup_plan_args = TopupPlanParameters(
+        total_exposure_time=100, instability_time=45, threshold_percentage=10
+    )
+    RE(plan(synchrotron_monitor, topup_plan_args))

--- a/src/artemis/beam_topup_plan.py
+++ b/src/artemis/beam_topup_plan.py
@@ -25,8 +25,10 @@ def get_synchrotron_monitor_from_parameters(topup_monitor_args: TopupParameters)
     return synchrotron_monitor
 
 
-def dummy_plan(synchrotron_monitor: SynchrotronMonitor):
-    for i in range(600):
+def dummy_plan(
+    synchrotron_monitor: SynchrotronMonitor,
+):
+    for i in range(30000):
         time.sleep(1)
         value = yield from rd(synchrotron_monitor)
         print(f"Plan is running. Step {i}, topup_gate={value}")

--- a/src/artemis/devices/synchrotron.py
+++ b/src/artemis/devices/synchrotron.py
@@ -1,5 +1,8 @@
 from ophyd import Component, Device, EpicsSignal
 
+# option to use tikit device instead of the real synchrotron PV's
+USE_TIKIT = False
+
 
 class SynchrotoronMachineStatus(Device):
     synchrotron_mode: EpicsSignal = Component(EpicsSignal, "MODE", string=True)
@@ -13,10 +16,14 @@ class SynchrotronTopUp(Device):
 
 
 class Synchrotron(Device):
+    machine_status_PV = "BL03S-CS-CS-MSTAT-01:" if USE_TIKIT else "CS-CS-MSTAT-01:"
+    top_up_PV = "BL03S-SR-CS-FILL-01:" if USE_TIKIT else "SR-CS-FILL-01:"
+    ring_current_PV = (
+        "BL03S-SR-DI-DCCT-01:SIGNAL" if USE_TIKIT else "SR-DI-DCCT-01:SIGNAL"
+    )
 
     machine_status: SynchrotoronMachineStatus = Component(
-        SynchrotoronMachineStatus, "CS-CS-MSTAT-01:"
+        SynchrotoronMachineStatus, machine_status_PV
     )
-    top_up: SynchrotronTopUp = Component(SynchrotronTopUp, "SR-CS-FILL-01:")
-
-    ring_current: EpicsSignal = Component(EpicsSignal, "SR-DI-DCCT-01:SIGNAL")
+    top_up: SynchrotronTopUp = Component(SynchrotronTopUp, top_up_PV)
+    ring_current: EpicsSignal = Component(EpicsSignal, ring_current_PV)

--- a/src/artemis/devices/synchrotron_monitor.py
+++ b/src/artemis/devices/synchrotron_monitor.py
@@ -38,16 +38,7 @@ class SynchrotronMonitor(Device):
             not (mode_precludes_gating or sufficient_time_before_topup)
             and topup_degrades_exposure
         )
-        """
-        # for testing
-        return [
-            "not dummy",
-            mode_precludes_gating,
-            sufficient_time_before_topup,
-            topup_degrades_exposure,
-            delay_required,
-        ]
-        """
+
         return delay_required
 
     @staticmethod
@@ -58,15 +49,7 @@ class SynchrotronMonitor(Device):
         return 100.0 * time_beam_unstable / total_exposure_time > threshold_percentage
 
     def _mode_precludes_gating(self, time_to_topup):
-        return (
-            self._in_decay_mode(time_to_topup)
-            or not self._gating_permitted_in_machine_mode()
-        )
-
-    def _gating_permitted_in_machine_mode(self):
-        machine_mode = self.synchrotron.machine_status.synchrotron_mode.get()
-        permitted_modes = ("User", "Special")
-        return machine_mode in permitted_modes
+        return self._in_decay_mode(time_to_topup)
 
     @staticmethod
     def _in_decay_mode(time_to_topup):

--- a/src/artemis/devices/synchrotron_monitor.py
+++ b/src/artemis/devices/synchrotron_monitor.py
@@ -11,6 +11,7 @@ class SynchrotronMonitor(Device):
     time_beam_unstable_signal: Signal = Component(Signal)
     threshold_percentage_signal: Signal = Component(Signal)
     topup_gate_signal: Signal = Component(Signal, value=True)
+    dummy_topup_gate_signal: Signal = Component(Signal, value=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -37,6 +38,16 @@ class SynchrotronMonitor(Device):
             not (mode_precludes_gating or sufficient_time_before_topup)
             and topup_degrades_exposure
         )
+        """
+        # for testing
+        return [
+            "not dummy",
+            mode_precludes_gating,
+            sufficient_time_before_topup,
+            topup_degrades_exposure,
+            delay_required,
+        ]
+        """
         return delay_required
 
     @staticmethod

--- a/src/artemis/devices/synchrotron_monitor.py
+++ b/src/artemis/devices/synchrotron_monitor.py
@@ -1,0 +1,67 @@
+from ophyd import Component, Device, Signal
+
+from artemis.devices.synchrotron import Synchrotron
+
+
+class SynchrotronMonitor(Device):
+
+    synchrotron: Synchrotron = Component(Synchrotron)
+    total_exposure_time_signal: Signal = Component(Signal, value=1)
+    # Seconds of estimated beam instability following topup:
+    time_beam_unstable_signal: Signal = Component(Signal)
+    threshold_percentage_signal: Signal = Component(Signal)
+    topup_gate_signal: Signal = Component(Signal, value=True)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.synchrotron.top_up.topup_end_countdown.subscribe(
+            self.set_topup_gate_signal
+        )
+
+    def set_topup_gate_signal(self, *_, **__):
+        self.topup_gate_signal.put(self.get_topup_gate())
+
+    def get_topup_gate(self):
+        total_exposure_time = self.total_exposure_time_signal.get()
+        time_to_topup = self.synchrotron.top_up.topup_start_countdown.get()
+        mode_precludes_gating = self._mode_precludes_gating(time_to_topup)
+        sufficient_time_before_topup = self._sufficient_time_before_topup(
+            time_to_topup, total_exposure_time
+        )
+        time_beam_unstable = self.time_beam_unstable_signal.get()
+        threshold_percentage = self.threshold_percentage_signal.get()
+        topup_degrades_exposure = self._topup_degrades_exposure(
+            total_exposure_time, time_beam_unstable, threshold_percentage
+        )
+        delay_required = (
+            not (mode_precludes_gating or sufficient_time_before_topup)
+            and topup_degrades_exposure
+        )
+        return delay_required
+
+    @staticmethod
+    def _topup_degrades_exposure(
+        total_exposure_time, time_beam_unstable, threshold_percentage
+    ):
+        # return True if topup duration eats a significant fraction of planned exposure time
+        return 100.0 * time_beam_unstable / total_exposure_time > threshold_percentage
+
+    def _mode_precludes_gating(self, time_to_topup):
+        return (
+            self._in_decay_mode(time_to_topup)
+            or not self._gating_permitted_in_machine_mode()
+        )
+
+    def _gating_permitted_in_machine_mode(self):
+        machine_mode = self.synchrotron.machine_status.synchrotron_mode.get()
+        permitted_modes = ("User", "Special")
+        return machine_mode in permitted_modes
+
+    @staticmethod
+    def _in_decay_mode(time_to_topup):
+        # If this is -1 we're in decay mode so no need to gate as no topup
+        return time_to_topup == -1
+
+    @staticmethod
+    def _sufficient_time_before_topup(time_to_topup, total_exposure_time):
+        return time_to_topup > total_exposure_time

--- a/src/artemis/topup_parameters.py
+++ b/src/artemis/topup_parameters.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+from dataclasses_json import dataclass_json
+
+
+@dataclass
+@dataclass_json
+class TopupParameters:
+    instability_time: float
+    threshold_percentage: float
+    total_exposure_time: float


### PR DESCRIPTION
Fist pass at making use of a suspender that pauses artemis when beam is being topped up (#127 )
Suspension conditions logic is copied from GDA into a new `SynchrotronMonitor` device.
A dummy plan that does nothing but print once a second is added; an endpoint is also added so that it can be run as `curl -X PUT http://127.0.0.1:5000/dummy/start`. A suspender using the `topup_gate_signal` signal of the `SynchrotronMonitor` is added to the run engine before executing the dummy plan. The plan should be paused whenever this signal is `True`, this sometimes happens, but usually does not. Running the same plan with the same configuration in the `__main__` of `beam_topup_plan.py` gives the same behaviour, but also gives a useful error message:
```
Subscription value callback exception (Signal(name='monitor_topup_gate_signal', parent='monitor', value=True, timestamp=1663862377.5352824))
Traceback (most recent call last):
  File "/dls/science/users/zzg91958/python-artemis/.venv/lib/python3.10/site-packages/ophyd/ophydobj.py", line 474, in inner
    cb(*args, **kwargs)
  File "/dls/science/users/zzg91958/python-artemis/.venv/lib/python3.10/site-packages/bluesky/suspenders.py", line 145, in __call__
    raise RuntimeError("Could not create the ")
RuntimeError: Could not create the 
```