### PR TITLE
Put the FastGridScan device in I03Smargon. 

### DIFF
--- a/src/artemis/devices/fast_grid_scan.py
+++ b/src/artemis/devices/fast_grid_scan.py
@@ -16,7 +16,7 @@ from ophyd import (
 from ophyd.status import DeviceStatus, StatusBase
 from ophyd.utils.epics_pvs import set_and_wait
 
-from artemis.devices.motors import XYZLimitBundle
+# from artemis.devices.motors import XYZLimitBundle
 from artemis.devices.status import await_value
 from artemis.utils import Point3D
 
@@ -68,7 +68,7 @@ class GridScanParams:
         self.z_axis = GridAxis(self.z2_start, self.z_step_size, self.z_steps)
         self.axes = [self.x_axis, self.y_axis, self.z_axis]
 
-    def is_valid(self, limits: XYZLimitBundle) -> bool:
+    def is_valid(self, limits) -> bool:
         """
         Validates scan parameters
 

--- a/src/artemis/devices/fast_grid_scan_composite.py
+++ b/src/artemis/devices/fast_grid_scan_composite.py
@@ -1,6 +1,5 @@
 from ophyd import Component, Device, FormattedComponent
 
-from artemis.devices.fast_grid_scan import FastGridScan
 from artemis.devices.motors import I03Smargon
 from artemis.devices.slit_gaps import SlitGaps
 from artemis.devices.synchrotron import Synchrotron
@@ -10,8 +9,6 @@ from artemis.devices.zebra import Zebra
 
 class FGSComposite(Device):
     """A device consisting of all the Devices required for a fast gridscan."""
-
-    fast_grid_scan = Component(FastGridScan, "-MO-SGON-01:FGS:")
 
     zebra = Component(Zebra, "-EA-ZEBRA-01:")
 

--- a/src/artemis/devices/motors.py
+++ b/src/artemis/devices/motors.py
@@ -4,6 +4,8 @@ from ophyd import EpicsMotor
 from ophyd.device import Component
 from ophyd.epics_motor import MotorBundle
 
+from artemis.devices.fast_grid_scan import FastGridScan
+
 
 @dataclass
 class MotorLimitHelper:
@@ -44,6 +46,7 @@ class I03Smargon(MotorBundle):
     y: EpicsMotor = Component(EpicsMotor, "Y")
     z: EpicsMotor = Component(EpicsMotor, "Z")
     omega: EpicsMotor = Component(EpicsMotor, "OMEGA")
+    fast_grid_scan = Component(FastGridScan, "FGS")
 
     def get_xyz_limits(self) -> XYZLimitBundle:
         """Get the limits for the x, y and z axes.

--- a/src/artemis/fast_grid_scan_plan.py
+++ b/src/artemis/fast_grid_scan_plan.py
@@ -68,7 +68,7 @@ def run_gridscan(
         else StoreInIspyb2D(ispyb_config, parameters)
     )
 
-    fgs_motors = fgs_composite.fast_grid_scan
+    fgs_motors = fgs_composite.sample_motors.fast_grid_scan
     zebra = fgs_composite.zebra
 
     # TODO: Check topup gate


### PR DESCRIPTION
We should rethink where the I03Smargon class should go - using it in motors.py is problematic as the is_valid function in fast_grid_scan.py uses the XYZLimitBundle class as a type for the limits it imports, which can't be imported from motors.py without a circular import error. #155