### PR TITLE
#312 a very basic fake zocalo

### DIFF
--- a/fake_zocalo/README.rst
+++ b/fake_zocalo/README.rst
@@ -1,0 +1,11 @@
+fake_zocalo
+===========================
+
+.. note::
+
+    This is meant to be used for testing artemis. Don't try to process any real
+    data with it! You will just get back (1.2, 2.3, 3.4).
+
+## To run:
+- You first need to run `module load rabbitmq/dev`, which starts the rabbitmq server and generates some credentials in ~/.fake_zocalo
+- And `module load dials/latest` in the shell running artemis, which allows the `devrmq` zocalo environment to be used

--- a/fake_zocalo/README.rst
+++ b/fake_zocalo/README.rst
@@ -7,5 +7,7 @@ fake_zocalo
     data with it! You will just get back (1.2, 2.3, 3.4).
 
 ## To run:
-- You first need to run `module load rabbitmq/dev`, which starts the rabbitmq server and generates some credentials in ~/.fake_zocalo
-- And `module load dials/latest` in the shell running artemis, which allows the `devrmq` zocalo environment to be used
+
+* Run `dls_start_fake_zocalo.sh`
+* For Artemis to connect to this you will need to run `module load dials/latest` in the terminal you're runnign Artemis in
+

--- a/fake_zocalo/__main__.py
+++ b/fake_zocalo/__main__.py
@@ -68,6 +68,7 @@ def main():
     conn = pika.BlockingConnection(params)
     channel = conn.channel()
     channel.basic_consume(queue="processing_recipe", on_message_callback=on_request)
+    print("Listening for zocalo requests")
     channel.start_consuming()
 
 

--- a/fake_zocalo/__main__.py
+++ b/fake_zocalo/__main__.py
@@ -1,0 +1,75 @@
+import json
+import os
+import time
+from pathlib import Path
+
+import pika
+import yaml
+from pika.adapters.blocking_connection import BlockingChannel
+from pika.spec import BasicProperties
+
+
+def load_configuration_file(filename):
+    conf = yaml.safe_load(Path(filename).read_text())
+    return conf
+
+
+def main():
+    config = load_configuration_file(
+        os.path.expanduser("~/.zocalo/rabbitmq-credentials.yml")
+    )
+    creds = pika.PlainCredentials(config["username"], config["password"])
+    params = pika.ConnectionParameters(
+        config["host"], config["port"], config["vhost"], creds
+    )
+
+    result = {
+        "environment": {"ID": "6261b482-bef2-49f5-8699-eb274cd3b92e"},
+        "payload": [{"max_voxel": [1, 2, 3], "centre_of_mass": [1.2, 2.3, 3.4]}],
+        "recipe": {
+            "start": [
+                [1, [{"max_voxel": [1, 2, 3], "centre_of_mass": [1.2, 2.3, 3.4]}]]
+            ],
+            "1": {
+                "service": "Send XRC results to GDA",
+                "queue": "xrc.i03",
+                "exchange": "results",
+                "parameters": {"dcid": "2", "dcgid": "4"},
+            },
+        },
+        "recipe-path": [],
+        "recipe-pointer": 1,
+    }
+
+    def on_request(ch: BlockingChannel, method, props, body):
+        print(
+            f"recieved message: \n properties: \n\n {method} \n\n {props} \n\n{body}\n"
+        )
+        try:
+            message = json.loads(body)
+        except Exception:
+            print("Malformed message body.")
+            return
+        if message.get("parameters").get("event") == "end":
+            print('Doing "processing"...')
+            time.sleep(3)
+            print('Sending "results"...')
+            resultprops = BasicProperties(
+                delivery_mode=2,
+                headers={"workflows-recipe": True, "x-delivery-count": 1},
+            )
+            result_chan = conn.channel()
+            result_chan.basic_publish(
+                "results", "xrc.i03", json.dumps(result), resultprops
+            )
+            print("Finished.\n")
+        ch.basic_ack(method.delivery_tag, False)
+
+    conn = pika.BlockingConnection(params)
+    channel = conn.channel()
+    channel.basic_consume(queue="processing_recipe", on_message_callback=on_request)
+    channel.start_consuming()
+
+
+if __name__ == "__main__":
+    main()

--- a/fake_zocalo/dls_start_fake_zocalo.sh
+++ b/fake_zocalo/dls_start_fake_zocalo.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# kills the gda dummy activemq, that takes the port for rabbitmq
+module load dasctools
+activemq-for-dummy stop
+
+# starts the rabbitmq server and generates some credentials in ~/.fake_zocalo
+module load rabbitmq/dev
+
+# allows the `devrmq` zocalo environment to be used
+module load dials/latest
+
+source .venv/bin/activate
+python fake_zocalo/__main__.py

--- a/src/artemis/tests/test_zocalo_system.py
+++ b/src/artemis/tests/test_zocalo_system.py
@@ -1,0 +1,17 @@
+import pytest
+
+from artemis.parameters import Point3D
+from artemis.zocalo_interaction import run_end, run_start, wait_for_result
+
+
+@pytest.mark.skip(
+    "Requires being able to change the zocalo env (https://github.com/DiamondLightSource/python-artemis/issues/356)"
+)
+@pytest.mark.s03
+def test_when_running_start_stop_then_get_expected_returned_results():
+    dcids = [1, 2]
+    for dcid in dcids:
+        run_start(dcid)
+    for dcid in dcids:
+        run_end(dcid)
+    assert wait_for_result(4) == Point3D(x=3.4, y=2.3, z=1.2)


### PR DESCRIPTION
- consumes 'end_run()' message
- sends back "results" for dcgid 4

Fixes #312

### To test:
1. Run `module load rabbitmq/dev` and fake zocalo main.py in one terminal
2. Run `module load dials/latest`, set artemis zocalo environment to `devrmq` and end run_end() and wait_for_result() from a python shell in another terminal and see that the request is "processed" and a "result" is returned.
