### PR TITLE
248: Checks the scan invalid straight after setting the params

### DIFF
--- a/src/artemis/devices/fast_grid_scan.py
+++ b/src/artemis/devices/fast_grid_scan.py
@@ -3,7 +3,7 @@ import time
 from dataclasses import dataclass
 from typing import List
 
-from bluesky.plan_stubs import mv
+from bluesky.plan_stubs import mv, rd
 from dataclasses_json import dataclass_json
 from ophyd import (
     Component,
@@ -262,6 +262,7 @@ class FastGridScan(Device):
 
 
 def set_fast_grid_scan_params(scan: FastGridScan, params: GridScanParams):
+    """Sets the scan parameters. Will throw an Exception if the scan is invalid."""
     yield from mv(
         scan.x_steps,
         params.x_steps,
@@ -288,3 +289,6 @@ def set_fast_grid_scan_params(scan: FastGridScan, params: GridScanParams):
         scan.z2_start,
         params.z2_start,
     )
+    scan_invalid = yield from rd(scan.scan_invalid)
+    if scan_invalid:
+        raise Exception("Provided grid scan parameters out of controller range")


### PR DESCRIPTION
Fixes #248

This should fix the original issue assuming:
* The scan invalid PV is always correct after the param callbacks (see question at https://github.com/DiamondLightSource/python-artemis/issues/248#issuecomment-1307597464)
* That exceptions raised during the run now get put into the ispyb comment

### To test:
1. To Do
