### PR TITLE
301 add zocalo environment parameter

### DIFF
--- a/src/artemis/fgs_communicator.py
+++ b/src/artemis/fgs_communicator.py
@@ -68,7 +68,7 @@ class FGSCommunicator(CallbackBase):
             datacollection_ids = self.ispyb_ids[0]
             self.datacollection_group_id = self.ispyb_ids[2]
             for id in datacollection_ids:
-                run_start(id)
+                run_start(id, self.params.zocalo_environment)
 
     def stop(self, doc: dict):
         artemis.log.LOGGER.debug(f"\n\nReceived stop document:\n\n {doc}\n")
@@ -83,11 +83,13 @@ class FGSCommunicator(CallbackBase):
         self.ispyb.end_deposition(exit_status)
         datacollection_ids = self.ispyb_ids[0]
         for id in datacollection_ids:
-            run_end(id)
+            run_end(id, self.params.zocalo_environment)
 
     def wait_for_results(self):
         datacollection_group_id = self.ispyb_ids[2]
-        self.results = wait_for_result(datacollection_group_id)
+        self.results = wait_for_result(
+            datacollection_group_id, self.params.zocalo_environment
+        )
         self.processing_time = time.time() - self.processing_start_time
         self.xray_centre_motor_position = (
             self.params.grid_scan_params.grid_position_to_motor_position(self.results)

--- a/src/artemis/parameters.py
+++ b/src/artemis/parameters.py
@@ -11,6 +11,7 @@ from artemis.utils import Point3D
 SIM_BEAMLINE = "BL03S"
 SIM_INSERTION_PREFIX = "SR03S"
 ISPYB_PLAN_NAME = "ispyb_readings"
+SIM_ZOCALO_ENV = "devrmq"
 
 
 def default_field(obj):
@@ -20,7 +21,7 @@ def default_field(obj):
 @dataclass_json
 @dataclass
 class FullParameters:
-    zocalo_environment: str = "devrmq"
+    zocalo_environment: str = SIM_ZOCALO_ENV
     beamline: str = SIM_BEAMLINE
     insertion_prefix: str = SIM_INSERTION_PREFIX
     grid_scan_params: GridScanParams = default_field(

--- a/src/artemis/parameters.py
+++ b/src/artemis/parameters.py
@@ -20,7 +20,7 @@ def default_field(obj):
 @dataclass_json
 @dataclass
 class FullParameters:
-    zocalo_environment: str = "artemis"
+    zocalo_environment: str = "devrmq"
     beamline: str = SIM_BEAMLINE
     insertion_prefix: str = SIM_INSERTION_PREFIX
     grid_scan_params: GridScanParams = default_field(

--- a/src/artemis/parameters.py
+++ b/src/artemis/parameters.py
@@ -20,6 +20,7 @@ def default_field(obj):
 @dataclass_json
 @dataclass
 class FullParameters:
+    zocalo_environment: str = "artemis"
     beamline: str = SIM_BEAMLINE
     insertion_prefix: str = SIM_INSERTION_PREFIX
     grid_scan_params: GridScanParams = default_field(

--- a/src/artemis/tests/test_fgs_communicator.py
+++ b/src/artemis/tests/test_fgs_communicator.py
@@ -10,6 +10,7 @@ from artemis.fgs_communicator import FGSCommunicator
 from artemis.parameters import (
     ISPYB_PLAN_NAME,
     SIM_BEAMLINE,
+    SIM_ZOCALO_ENV,
     DetectorParams,
     FullParameters,
 )
@@ -102,10 +103,10 @@ def test_run_gridscan_zocalo_calls(
     communicator.event(test_event_document)
     communicator.stop(test_stop_document)
 
-    run_start.assert_has_calls([call(x, "artemis") for x in dc_ids])
+    run_start.assert_has_calls([call(x, SIM_ZOCALO_ENV) for x in dc_ids])
     assert run_start.call_count == len(dc_ids)
 
-    run_end.assert_has_calls([call(x, "artemis") for x in dc_ids])
+    run_end.assert_has_calls([call(x, SIM_ZOCALO_ENV) for x in dc_ids])
     assert run_end.call_count == len(dc_ids)
 
     wait_for_result.assert_not_called()
@@ -122,7 +123,7 @@ def test_zocalo_called_to_wait_on_results_when_communicator_wait_for_results_cal
     wait_for_result.return_value = expected_centre_grid_coords
 
     communicator.wait_for_results()
-    wait_for_result.assert_called_once_with(100, "artemis")
+    wait_for_result.assert_called_once_with(100, SIM_ZOCALO_ENV)
     expected_centre_motor_coords = (
         params.grid_scan_params.grid_position_to_motor_position(
             expected_centre_grid_coords

--- a/src/artemis/tests/test_fgs_communicator.py
+++ b/src/artemis/tests/test_fgs_communicator.py
@@ -102,10 +102,10 @@ def test_run_gridscan_zocalo_calls(
     communicator.event(test_event_document)
     communicator.stop(test_stop_document)
 
-    run_start.assert_has_calls([call(x) for x in dc_ids])
+    run_start.assert_has_calls([call(x, "artemis") for x in dc_ids])
     assert run_start.call_count == len(dc_ids)
 
-    run_end.assert_has_calls([call(x) for x in dc_ids])
+    run_end.assert_has_calls([call(x, "artemis") for x in dc_ids])
     assert run_end.call_count == len(dc_ids)
 
     wait_for_result.assert_not_called()
@@ -122,7 +122,7 @@ def test_zocalo_called_to_wait_on_results_when_communicator_wait_for_results_cal
     wait_for_result.return_value = expected_centre_grid_coords
 
     communicator.wait_for_results()
-    wait_for_result.assert_called_once_with(100)
+    wait_for_result.assert_called_once_with(100, "artemis")
     expected_centre_motor_coords = (
         params.grid_scan_params.grid_position_to_motor_position(
             expected_centre_grid_coords

--- a/src/artemis/tests/test_zocalo_interaction.py
+++ b/src/artemis/tests/test_zocalo_interaction.py
@@ -10,7 +10,7 @@ from pytest import mark, raises
 from zocalo.configuration import Configuration
 
 from artemis.ispyb.ispyb_dataclass import Point3D
-from artemis.parameters import FullParameters
+from artemis.parameters import SIM_ZOCALO_ENV
 from artemis.zocalo_interaction import run_end, run_start, wait_for_result
 
 EXPECTED_DCID = 100
@@ -20,8 +20,6 @@ EXPECTED_RUN_END_MESSAGE = {
     "ispyb_dcid": EXPECTED_DCID,
     "ispyb_wait_for_runstatus": "1",
 }
-params = FullParameters()
-ZOCALO_ENV = params.zocalo_environment
 
 
 @patch("zocalo.configuration.from_file")
@@ -37,7 +35,7 @@ def _test_zocalo(
 
     func_testing(mock_transport)
 
-    mock_zc.activate_environment.assert_called_once_with(ZOCALO_ENV)
+    mock_zc.activate_environment.assert_called_once_with(SIM_ZOCALO_ENV)
     mock_transport.connect.assert_called_once()
     expected_message = {
         "recipes": ["mimas"],
@@ -83,7 +81,7 @@ def test_run_start_and_end(
         function_wrapper (Callable): A wrapper around the function, used to test for expected exceptions
         expected_message (Dict): The expected dictionary sent to zocalo
     """
-    function_to_run = partial(function_to_test, EXPECTED_DCID, ZOCALO_ENV)
+    function_to_run = partial(function_to_test, EXPECTED_DCID, SIM_ZOCALO_ENV)
     function_to_run = partial(function_wrapper, function_to_run)
     _test_zocalo(function_to_run, expected_message)
 
@@ -113,7 +111,9 @@ def test_when_message_recieved_from_zocalo_then_point_returned(
     mock_transport_lookup.return_value.return_value = mock_transport
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        future = executor.submit(wait_for_result, datacollection_grid_id, ZOCALO_ENV)
+        future = executor.submit(
+            wait_for_result, datacollection_grid_id, SIM_ZOCALO_ENV
+        )
 
         for _ in range(10):
             sleep(0.1)

--- a/src/artemis/tests/test_zocalo_interaction.py
+++ b/src/artemis/tests/test_zocalo_interaction.py
@@ -80,7 +80,7 @@ def test_run_start_and_end(
         function_wrapper (Callable): A wrapper around the function, used to test for expected exceptions
         expected_message (Dict): The expected dictionary sent to zocalo
     """
-    function_to_run = partial(function_to_test, EXPECTED_DCID)
+    function_to_run = partial(function_to_test, EXPECTED_DCID, "artemis")
     function_to_run = partial(function_wrapper, function_to_run)
     _test_zocalo(function_to_run, expected_message)
 
@@ -110,7 +110,7 @@ def test_when_message_recieved_from_zocalo_then_point_returned(
     mock_transport_lookup.return_value.return_value = mock_transport
 
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        future = executor.submit(wait_for_result, datacollection_grid_id)
+        future = executor.submit(wait_for_result, datacollection_grid_id, "artemis")
 
         for _ in range(10):
             sleep(0.1)

--- a/src/artemis/tests/test_zocalo_interaction.py
+++ b/src/artemis/tests/test_zocalo_interaction.py
@@ -34,7 +34,7 @@ def _test_zocalo(
 
     func_testing(mock_transport)
 
-    mock_zc.activate_environment.assert_called_once_with("artemis")
+    mock_zc.activate_environment.assert_called_once_with("devrmq")
     mock_transport.connect.assert_called_once()
     expected_message = {
         "recipes": ["mimas"],

--- a/src/artemis/zocalo_interaction.py
+++ b/src/artemis/zocalo_interaction.py
@@ -13,7 +13,7 @@ from artemis.utils import Point3D
 TIMEOUT = 90
 
 
-def _get_zocalo_connection(env):
+def _get_zocalo_connection(env: str = "artemis"):
     zc = zocalo.configuration.from_file()
     zc.activate_environment(env)
 

--- a/test_parameters.json
+++ b/test_parameters.json
@@ -1,6 +1,7 @@
 {
     "beamline": "BL03S",
     "detector": "EIGER2_X_16M",
+    "zocalo_environment": "devrmq",
     "grid_scan_params": {
         "x_steps": 5,
         "y_steps": 10,


### PR DESCRIPTION
Fixes #301 

Adds a parameter to parameters and zocalo_interaction in order to be able to specify the data processing (zocalo) environment at runtime. ~~Defaults to production "artemis" env if not specified, so it should not break any existing parameter configurations.~~ Mainly so that we can change to "devrmq" for testing and mock out zocalo; test_parameters.json is updated to reflect this.

Defaults to devrmq because it's too dangerous to be able to accidentally send requests to prod zocalo, see #356 

### To test:
1. verify tests still pass
