### PR TITLE
408 test nexus file

### DIFF
--- a/dls_dev_env.sh
+++ b/dls_dev_env.sh
@@ -12,6 +12,8 @@ fi
 mkdir .venv
 
 python -m venv .venv
+# get dlstbx into our env
+ln -s /dls_sw/apps/dials/latest/latest/modules/dlstbx/src/dlstbx/ .venv/lib/python3.10/site-packages/dlstbx
 source .venv/bin/activate
 pip install -e .[dev]
 

--- a/src/artemis/external_interaction/nexus_writing/tests/test_write_nexus.py
+++ b/src/artemis/external_interaction/nexus_writing/tests/test_write_nexus.py
@@ -256,7 +256,7 @@ def test_nexus_writer_writes_width_and_height_correctly(single_dummy_file):
     assert single_dummy_file.detector["image_size"][1] == PIXELS_X_EIGER2_X_4M
 
 
-def test_nexus_file_validity_for_zocalo_with_two_vds(
+def test_nexus_file_validity_for_zocalo_with_two_linked_datasets(
     dummy_nexus_writers: tuple[NexusWriter, NexusWriter]
 ):
     nexus_writer_1, nexus_writer_2 = dummy_nexus_writers
@@ -277,7 +277,7 @@ def test_nexus_file_validity_for_zocalo_with_two_vds(
             )
 
 
-def test_nexus_file_validity_for_zocalo_with_three_vds(
+def test_nexus_file_validity_for_zocalo_with_three_linked_datasets(
     dummy_nexus_writers_with_more_images: tuple[NexusWriter, NexusWriter]
 ):
     nexus_writer_1, nexus_writer_2 = dummy_nexus_writers_with_more_images


### PR DESCRIPTION
Doesn't actually resolve #408, but adds tests using `dials.dlstbx.swmr.h5check`

### To test:
1. Run tests
2. see the new test for nexus files where all linked datasets are used passes
3. see the new test for nexus files where not all linked datasets are used fails
