### PR TITLE
Fix checking for host/user in run_artemis

### DIFF
--- a/run_artemis.sh
+++ b/run_artemis.sh
@@ -84,8 +84,9 @@ fi
 SSH_KEY_FILE_LOC="/dls_sw/${BEAMLINE}/software/gda_versions/var/.ssh/${BEAMLINE}-ssh.key"
 
 if [[ $STOP == 1 ]]; then
-    if [[ $HOSTNAME != "${BEAMLINE}-control@diamond.ac.uk" ]]; then
+    if [[ $HOSTNAME != "${BEAMLINE}-control.diamond.ac.uk" || $USER != "gda2" ]]; then
         echo "Must be run from beamline control machine as gda2"
+        echo "Current host is $HOSTNAME and user is $USER"
         exit 1
     fi
     pkill -f "python -m artemis"
@@ -133,8 +134,9 @@ if [[ $DEPLOY == 1 ]]; then
 fi
 
 if [[ $START == 1 ]]; then
-    if [[ $HOSTNAME != "${BEAMLINE}-control@diamond.ac.uk" || $USERNAME != "gda2" ]]; then
+    if [[ $HOSTNAME != "${BEAMLINE}-control.diamond.ac.uk" || $USER != "gda2" ]]; then
         echo "Must be run from beamline control machine as gda2"
+        echo "Current host is $HOSTNAME and user is $USER"
         exit 1
     fi
 


### PR DESCRIPTION

### To test:
1. Tested on beamline 
2. for local testing just confirm that the error message printed now shows the user/hostname when script is run
