### PR TITLE
Update setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,8 +29,7 @@ install_requires =
     nexgen @ git+https://github.com/dials/nexgen.git@e3d2173b4723b2fbed022a7d22229bfe8c54c173
     opentelemetry-distro
     opentelemetry-exporter-jaeger
-    ophyd @ git+https://github.com/bluesky/ophyd.git@0895f9f00bdf7454712aa954ea7c7f3f1776fcb9
-
+    ophyd
     # For databroker
     humanize
     pandas


### PR DESCRIPTION
fixes #440 

### To test:
1. Clone a new copy of main and run `./dls_dev_env.sh`; see it fails to install ophyd from github
2. Confirm the script succeeds with just `ophyd` as requirement
