### PR TITLE
399 redo random order tests

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -54,39 +54,11 @@ jobs:
 
 
       - name: Run tests
-        run: pytest --random-order -m "not s03"
+        run: pytest --random-order -m "not (dlstbx or s03)"
 
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           name: ${{ matrix.python }}/${{ matrix.os }}
-          files: cov.xml
-
-  container:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Log in to GitHub Docker Registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          name: ubuntu-latest
           files: cov.xml

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -54,7 +54,35 @@ jobs:
 
 
       - name: Run tests
-        run: pytest -m "not (s03 or dlstbx)"
+        run: pytest --random-order -m "not s03"
+
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          name: ${{ matrix.python }}/${{ matrix.os }}
+          files: cov.xml
+
+  container:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Log in to GitHub Docker Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/container_tests.sh
+++ b/.github/workflows/container_tests.sh
@@ -1,1 +1,1 @@
-pytest -m "not (s03 or dlstbx)"
+pytest --random-order -m "not (s03 or dlstbx)"

--- a/dls_dev_env.sh
+++ b/dls_dev_env.sh
@@ -12,9 +12,10 @@ fi
 mkdir .venv
 
 python -m venv .venv
-# get dlstbx into our env
-ln -s /dls_sw/apps/dials/latest/latest/modules/dlstbx/src/dlstbx/ .venv/lib/python3.10/site-packages/dlstbx
 source .venv/bin/activate
 pip install -e .[dev]
+
+# get dlstbx into our env
+ln -s /dls_sw/apps/dials/latest/latest/modules/dlstbx/src/dlstbx/ .venv/lib/python3.10/site-packages/dlstbx
 
 pytest -m "not s03"

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ dev =
     black
     isort>5.0
     pytest-cov
+    pytest-random-order
     ipython
     mockito
     pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,11 +74,11 @@ float_to_top=true
 [flake8]
 max-line-length = 88
 extend-ignore =
-# See https://github.com/PyCQA/pycodestyle/issues/373
+    # See https://github.com/PyCQA/pycodestyle/issues/373
     E203,  
-# support typing.overload decorator
+    # support typing.overload decorator
     F811,  
-# line too long
+    # line too long
     E501,  
 
 [coverage:run]

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,11 +74,11 @@ float_to_top=true
 [flake8]
 max-line-length = 88
 extend-ignore =
-    # See https://github.com/PyCQA/pycodestyle/issues/373
+# See https://github.com/PyCQA/pycodestyle/issues/373
     E203,  
-    # support typing.overload decorator
+# support typing.overload decorator
     F811,  
-    # line too long
+# line too long
     E501,  
 
 [coverage:run]


### PR DESCRIPTION
Fixes #399 
Replaces #407 

Randomises the order in which tests are run, including in CI, in order to help identify any interdependent tests.

### To test:
0. see tests pass even in a random order