### PR TITLE
442: Redirect stdout

### DIFF
--- a/run_artemis.sh
+++ b/run_artemis.sh
@@ -79,10 +79,13 @@ done
 if [ -z "${BEAMLINE}" ]; then
     echo "BEAMLINE parameter not set, assuming running on a dev machine."
     echo "If you would like to run not in dev use the option -b, --beamline=BEAMLNE to set it manually"
+    IN_DEV=true
+else
+    IN_DEV=false
 fi
 
 if [[ $STOP == 1 ]]; then
-    if [ -n "${BEAMLINE}" ]; then
+    if [ $IN_DEV == false ]; then
         if [[ $HOSTNAME != "${BEAMLINE}-control.diamond.ac.uk" || $USER != "gda2" ]]; then
             echo "Must be run from beamline control machine as gda2"
             echo "Current host is $HOSTNAME and user is $USER"
@@ -125,7 +128,7 @@ if [[ $DEPLOY == 1 ]]; then
 fi
 
 if [[ $START == 1 ]]; then
-    if [ -n "${BEAMLINE}" ]; then
+    if [ $IN_DEV == false ]; then
         if [[ $HOSTNAME != "${BEAMLINE}-control.diamond.ac.uk" || $USER != "gda2" ]]; then
             echo "Must be run from beamline control machine as gda2"
             echo "Current host is $HOSTNAME and user is $USER"
@@ -144,7 +147,7 @@ if [[ $START == 1 ]]; then
     module load dials
 
     source .venv/bin/activate
-    python -m artemis &
+    python -m artemis `if [ $IN_DEV == true ]; then echo "--dev"; fi` &
 
     echo "Artemis started"
 fi

--- a/run_artemis.sh
+++ b/run_artemis.sh
@@ -147,7 +147,7 @@ if [[ $START == 1 ]]; then
     module load dials
 
     source .venv/bin/activate
-    python -m artemis `if [ $IN_DEV == true ]; then echo "--dev"; fi` &
+    python -m artemis `if [ $IN_DEV == true ]; then echo "--dev"; fi` >/dev/null 2>&1 &
 
     echo "Artemis started"
 fi

--- a/src/artemis/__main__.py
+++ b/src/artemis/__main__.py
@@ -177,16 +177,20 @@ def cli_arg_parse() -> Tuple[Optional[bool], Optional[str]]:
 
 
 if __name__ == "__main__":
-    args = cli_arg_parse()
-    artemis.log.set_up_logging_handlers(*args)
+    artemis_port = 5005
+    logging_level, dev_mode = cli_arg_parse()
+    artemis.log.set_up_logging_handlers(logging_level, dev_mode)
     app, runner = create_app()
     atexit.register(runner.shutdown)
     flask_thread = threading.Thread(
         target=lambda: app.run(
-            host="0.0.0.0", port=5005, debug=True, use_reloader=False
+            host="0.0.0.0", port=artemis_port, debug=True, use_reloader=False
         ),
         daemon=True,
     )
     flask_thread.start()
+    artemis.log.LOGGER.info(
+        f"Artemis now listening on {artemis_port} ({'IN DEV' if dev_mode else ''})"
+    )
     runner.wait_on_queue()
     flask_thread.join()


### PR DESCRIPTION
Fixes #442

### To test:
1. Confirm running `run_artemis` on a dev machine will run artemis up in dev mode, with appropriate warnings that it's doing so
2. Check in `./tmp/dev/artemis.txt` for signs that it's started up in dev mode correctly
3. Remove the change from https://github.com/DiamondLightSource/python-artemis/commit/ff1e647cc7137b741799207a75620a29e88be3b6 and add the following code to `__main__.py`:
```python
    while True:
        from time import sleep
        sleep(0.1)
        print("Hello")
```
4. `run_artemis.sh` and close the terminal you run it from
5. In a new terminal confirm artemis has died `ps -aux | grep artemis`
6. Reinstate https://github.com/DiamondLightSource/python-artemis/commit/ff1e647cc7137b741799207a75620a29e88be3b6 but keep the modifications in `__main__`
7. Repeat 4-5 but confirm artemis has not died