### PR TITLE
Fix incorrect sample depends_on value

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ python_requires = >=3.8
 packages = find:
 package_dir =
     =src
-install_requires = 
+install_requires =
     bluesky
     pyepics
     flask-restful
@@ -25,8 +25,7 @@ install_requires =
     ispyb
     scanspec
     numpy
-    # Pinned until https://github.com/dials/nexgen/pull/92 is released
-    nexgen @ git+https://github.com/dials/nexgen.git@e3d2173b4723b2fbed022a7d22229bfe8c54c173
+    nexgen
     opentelemetry-distro
     opentelemetry-exporter-jaeger
     ophyd
@@ -75,14 +74,14 @@ float_to_top=true
 max-line-length = 88
 extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
-    E203,  
+    E203,
     # support typing.overload decorator
-    F811,  
+    F811,
     # line too long
-    E501,  
+    E501,
 
 [coverage:run]
-omit = 
+omit =
     # This is covered in the versiongit test suite so exclude it here
     */_version_git.py
 data_file = /tmp/python-artemis.coverage


### PR DESCRIPTION
Fixes #337 

This issue was due to an error inside the `nexgen` package, which has been fixed in version 0.6.12. Unpinning should will get the latest version (currently 0.6.16) - which also checks that unused datasets are not used as sources for the VDS.

