### PR TITLE
Zocalo no longer returns reversed coordinates

### DIFF
--- a/src/artemis/external_interaction/unit_tests/test_zocalo_interaction.py
+++ b/src/artemis/external_interaction/unit_tests/test_zocalo_interaction.py
@@ -134,4 +134,4 @@ def test_when_message_recieved_from_zocalo_then_point_returned(
         return_value = future.result()
 
     assert type(return_value) == Point3D
-    assert return_value == Point3D(*reversed(centre_of_mass_coords))
+    assert return_value == Point3D(*centre_of_mass_coords)

--- a/src/artemis/external_interaction/zocalo/zocalo_interaction.py
+++ b/src/artemis/external_interaction/zocalo/zocalo_interaction.py
@@ -99,7 +99,7 @@ class ZocaloInteractor:
             transport.ack(header)
             received_group_id = recipe_parameters["dcgid"]
             if received_group_id == str(data_collection_group_id):
-                result_received.put(Point3D(*reversed(message[0]["centre_of_mass"])))
+                result_received.put(Point3D(*message[0]["centre_of_mass"]))
             else:
                 artemis.log.LOGGER.warning(
                     f"Warning: results for {received_group_id} received but expected \


### PR DESCRIPTION
See python-dlstbx#196

### To test:
1. Test artemis X-ray centring with latest version of Zocalo X-ray centring service
2. Confirm that artemis moves to the correct location
