### PR TITLE
Tell Zocalo to no longer wait on run status

### DIFF
--- a/src/artemis/external_interaction/unit_tests/test_zocalo_interaction.py
+++ b/src/artemis/external_interaction/unit_tests/test_zocalo_interaction.py
@@ -22,7 +22,6 @@ EXPECTED_RUN_START_MESSAGE = {"event": "start", "ispyb_dcid": EXPECTED_DCID}
 EXPECTED_RUN_END_MESSAGE = {
     "event": "end",
     "ispyb_dcid": EXPECTED_DCID,
-    "ispyb_wait_for_runstatus": "1",
 }
 
 

--- a/src/artemis/external_interaction/zocalo/zocalo_interaction.py
+++ b/src/artemis/external_interaction/zocalo/zocalo_interaction.py
@@ -76,7 +76,6 @@ class ZocaloInteractor:
         self._send_to_zocalo(
             {
                 "event": "end",
-                "ispyb_wait_for_runstatus": "1",
                 "ispyb_dcid": data_collection_id,
             }
         )


### PR DESCRIPTION
Fixes #518 

I can't think of a brilliant way of testing this other than implementing the wait for run_status in fake_zocalo but I really don't want fake_zocalo to grow that much, particularly as we don't actually want the wait functionality.


### To test:
1. Run test