### PR TITLE
Trigger zocalo after eiger has staged

### DIFF
--- a/src/artemis/experiment_plans/fast_grid_scan_plan.py
+++ b/src/artemis/experiment_plans/fast_grid_scan_plan.py
@@ -175,9 +175,9 @@ def run_gridscan(
     yield from set_fast_grid_scan_params(fgs_motors, parameters.grid_scan_params)
     yield from wait_for_fgs_valid(fgs_motors)
 
-    @bpp.stage_decorator([eiger])
     @bpp.set_run_key_decorator("do_fgs")
     @bpp.run_decorator(md={"subplan_name": "do_fgs"})
+    @bpp.stage_decorator([eiger])
     def do_fgs():
         yield from bps.wait()  # Wait for all moves to complete
         yield from bps.kickoff(fgs_motors)


### PR DESCRIPTION
Fixes #535

### To test:
1. Have added https://github.com/DiamondLightSource/python-artemis/issues/536 for a good test
1. In the mean time you can use:
```python
import bluesky.plan_stubs as bps
import bluesky.preprocessors as bpp
from bluesky import RunEngine
from bluesky.callbacks import CallbackBase
from ophyd import Device


class MyDevice(Device):
    def unstage(self):
        print("Unstaging")


class MyCallback(CallbackBase):
    def stop(self, doc):
        print("Stopped")
        return super().stop(doc)


my_device = MyDevice(name="blah")


@bpp.set_run_key_decorator("do_fgs")
@bpp.run_decorator(md={"subplan_name": "do_fgs"})
@bpp.stage_decorator([my_device])
def my_plan():
    yield from bps.sleep(1)


@bpp.subs_decorator(MyCallback())
def test_plan():
    yield from my_plan()


RE = RunEngine()
RE(test_plan())
```
to test the concepts. Re-ordering the decorator in this will change the print statement ordering