### PR TITLE
524 setup zebra for rotation

### DIFF
--- a/src/artemis/device_setup_plans/setup_zebra_for_rotation.py
+++ b/src/artemis/device_setup_plans/setup_zebra_for_rotation.py
@@ -1,0 +1,29 @@
+import bluesky.plan_stubs as bps
+
+from artemis.devices.zebra import (
+    DISCONNECT,
+    OR1,
+    PC_PULSE,
+    TTL_DETECTOR,
+    TTL_SHUTTER,
+    TTL_XSPRESS3,
+    Zebra,
+)
+
+
+def setup_zebra_for_rotation(
+    zebra: Zebra, group="setup_zebra_for_rotation", wait=False
+):
+    # Need to:
+    # Trigger the detector with a pulse, (pulse step set to exposure time?)
+    # Trigger the shutter with the gate (from PC_GATE & SOFTIN1 -> OR1)
+    # Set gate start to current angle +1
+    # set gate width to total width
+
+    yield from bps.abs_set(zebra.output.out_pvs[TTL_DETECTOR], PC_PULSE, group=group)
+    yield from bps.abs_set(zebra.output.out_pvs[TTL_SHUTTER], OR1, group=group)
+    yield from bps.abs_set(zebra.output.out_pvs[TTL_XSPRESS3], DISCONNECT, group=group)
+    yield from bps.abs_set(zebra.output.pulse_1_input, DISCONNECT, group=group)
+
+    if wait:
+        bps.wait(group)

--- a/src/artemis/device_setup_plans/setup_zebra_for_rotation.py
+++ b/src/artemis/device_setup_plans/setup_zebra_for_rotation.py
@@ -12,6 +12,7 @@ from artemis.devices.zebra import (
     Zebra,
 )
 
+# TODO do this properly - get it from Eiger or something
 MINIMUM_EXPOSURE_TIME = 0.005
 
 

--- a/src/artemis/device_setup_plans/setup_zebra_for_rotation.py
+++ b/src/artemis/device_setup_plans/setup_zebra_for_rotation.py
@@ -1,4 +1,5 @@
 import bluesky.plan_stubs as bps
+from ophyd.status import SubscriptionStatus
 
 from artemis.devices.zebra import (
     DISCONNECT,
@@ -7,23 +8,66 @@ from artemis.devices.zebra import (
     TTL_DETECTOR,
     TTL_SHUTTER,
     TTL_XSPRESS3,
+    I03_axes,
     Zebra,
 )
 
+MINIMUM_EXPOSURE_TIME = 0.005
+
 
 def setup_zebra_for_rotation(
-    zebra: Zebra, group="setup_zebra_for_rotation", wait=False
+    zebra: Zebra,
+    axis: I03_axes = I03_axes.OMEGA,
+    start_angle: float = 0,
+    scan_width: float = 360,
+    exposure_time: float = MINIMUM_EXPOSURE_TIME,
+    group: str = "setup_zebra_for_rotation",
+    wait: bool = False,
 ):
-    # Need to:
-    # Trigger the detector with a pulse, (pulse step set to exposure time?)
-    # Trigger the shutter with the gate (from PC_GATE & SOFTIN1 -> OR1)
-    # Set gate start to current angle +1
-    # set gate width to total width
+    """Set up the Zebra to collect a rotation dataset. Any plan using this is
+    responsible for setting the smargon velocity appropriately so that the desired
+    image width is achieved with the exposure time given here.
 
+    Parameters:
+        axis:           I03 axes enum representing which axis to use for position
+                        compare. Currently always omega.
+        start_angle:    Position at which the scan should begin, in degrees.
+        scan_width:     Total angle through which to collect, in degrees.
+        exposure_time:  Time that each image is exposed, in seconds.
+
+
+    """
+    # Sanity check params:
+    if exposure_time < MINIMUM_EXPOSURE_TIME:
+        raise Exception(
+            f"Exposure time {exposure_time} less than allowed minimum of {MINIMUM_EXPOSURE_TIME}."
+        )
+
+    # Set gate start
+    yield from bps.abs_set(zebra.pc.gate_start, start_angle, group=group)
+    # set gate width to total width
+    yield from bps.abs_set(zebra.pc.gate_width, scan_width, group=group)
+    # Set gate position to be angle of interest
+    yield from bps.abs_set(zebra.pc.gate_trigger, axis.value, group=group)
+
+    # Trigger the detector with a pulse, (pulse step set to exposure time?)
     yield from bps.abs_set(zebra.output.out_pvs[TTL_DETECTOR], PC_PULSE, group=group)
+    yield from bps.abs_set(zebra.pc.pulse_step, exposure_time, group=group)
+    yield from bps.abs_set(zebra.pc.pulse_width, exposure_time / 2, group=group)
+
+    # Trigger the shutter with the gate (from PC_GATE & SOFTIN1 -> OR1)
     yield from bps.abs_set(zebra.output.out_pvs[TTL_SHUTTER], OR1, group=group)
+
     yield from bps.abs_set(zebra.output.out_pvs[TTL_XSPRESS3], DISCONNECT, group=group)
     yield from bps.abs_set(zebra.output.pulse_1_input, DISCONNECT, group=group)
 
     if wait:
         bps.wait(group)
+
+
+def setup_zebra_for_rotation_and_arm(
+    zebra: Zebra, group="setup_zebra_for_rotation", wait=False
+) -> SubscriptionStatus:
+    yield from setup_zebra_for_rotation(zebra, group, wait)
+
+    return zebra.pc.arm()

--- a/src/artemis/device_setup_plans/setup_zebra_for_rotation.py
+++ b/src/artemis/device_setup_plans/setup_zebra_for_rotation.py
@@ -1,5 +1,4 @@
 import bluesky.plan_stubs as bps
-from ophyd.status import SubscriptionStatus
 
 from artemis.devices.zebra import (
     DISCONNECT,

--- a/src/artemis/device_setup_plans/setup_zebra_for_rotation.py
+++ b/src/artemis/device_setup_plans/setup_zebra_for_rotation.py
@@ -21,7 +21,6 @@ def setup_zebra_for_rotation(
     axis: I03_axes = I03_axes.OMEGA,
     start_angle: float = 0,
     scan_width: float = 360,
-    exposure_time: float = MINIMUM_EXPOSURE_TIME,
     group: str = "setup_zebra_for_rotation",
     wait: bool = False,
 ):
@@ -34,16 +33,7 @@ def setup_zebra_for_rotation(
                         compare. Currently always omega.
         start_angle:    Position at which the scan should begin, in degrees.
         scan_width:     Total angle through which to collect, in degrees.
-        exposure_time:  Time that each image is exposed, in seconds.
-
-
     """
-    # Sanity check params:
-    if exposure_time < MINIMUM_EXPOSURE_TIME:
-        raise Exception(
-            f"Exposure time {exposure_time} less than allowed minimum of {MINIMUM_EXPOSURE_TIME}."
-        )
-
     # Set gate start
     yield from bps.abs_set(zebra.pc.gate_start, start_angle, group=group)
     # set gate width to total width
@@ -51,24 +41,14 @@ def setup_zebra_for_rotation(
     # Set gate position to be angle of interest
     yield from bps.abs_set(zebra.pc.gate_trigger, axis.value, group=group)
 
-    # Trigger the detector with a pulse, (pulse step set to exposure time?)
-    yield from bps.abs_set(zebra.output.out_pvs[TTL_DETECTOR], PC_PULSE, group=group)
-    yield from bps.abs_set(zebra.pc.pulse_step, exposure_time, group=group)
-    yield from bps.abs_set(zebra.pc.pulse_width, exposure_time / 2, group=group)
-
     # Trigger the shutter with the gate (from PC_GATE & SOFTIN1 -> OR1)
     yield from bps.abs_set(zebra.output.out_pvs[TTL_SHUTTER], OR1, group=group)
+
+    # Trigger the detector with a pulse
+    yield from bps.abs_set(zebra.output.out_pvs[TTL_DETECTOR], PC_PULSE, group=group)
 
     yield from bps.abs_set(zebra.output.out_pvs[TTL_XSPRESS3], DISCONNECT, group=group)
     yield from bps.abs_set(zebra.output.pulse_1_input, DISCONNECT, group=group)
 
     if wait:
         bps.wait(group)
-
-
-def setup_zebra_for_rotation_and_arm(
-    zebra: Zebra, group="setup_zebra_for_rotation", wait=False
-) -> SubscriptionStatus:
-    yield from setup_zebra_for_rotation(zebra, group, wait)
-
-    return zebra.pc.arm()

--- a/src/artemis/device_setup_plans/setup_zebra_for_rotation.py
+++ b/src/artemis/device_setup_plans/setup_zebra_for_rotation.py
@@ -11,9 +11,6 @@ from artemis.devices.zebra import (
     Zebra,
 )
 
-# TODO do this properly - get it from Eiger or something
-MINIMUM_EXPOSURE_TIME = 0.005
-
 
 def setup_zebra_for_rotation(
     zebra: Zebra,

--- a/src/artemis/devices/eiger.py
+++ b/src/artemis/devices/eiger.py
@@ -138,7 +138,7 @@ class EigerDetector(Device):
         status &= self.cam.trigger_mode.set(EigerTriggerMode.EXTERNAL_SERIES.value)
         return status
 
-    def set_odin_pvs(self):
+    def set_odin_pvs(self) -> AndStatus:
         self.odin.file_writer.num_frames_chunks.set(1).wait(10)
 
         file_prefix = self.detector_params.full_filename
@@ -153,7 +153,7 @@ class EigerDetector(Device):
 
         return odin_status
 
-    def set_mx_settings_pvs(self) -> Status:
+    def set_mx_settings_pvs(self) -> AndStatus:
         assert self.detector_params is not None
         beam_x_pixels, beam_y_pixels = self.detector_params.get_beam_position_pixels(
             self.detector_params.detector_distance

--- a/src/artemis/devices/eiger.py
+++ b/src/artemis/devices/eiger.py
@@ -139,6 +139,7 @@ class EigerDetector(Device):
         return status
 
     def set_odin_pvs(self) -> AndStatus:
+        assert self.detector_params is not None
         self.odin.file_writer.num_frames_chunks.set(1).wait(10)
 
         file_prefix = self.detector_params.full_filename

--- a/src/artemis/devices/zebra.py
+++ b/src/artemis/devices/zebra.py
@@ -58,8 +58,6 @@ class PositionCompare(Device):
 
     pulse_source: EpicsSignal = epics_signal_put_wait("PC_PULSE_SEL")
     pulse_input: EpicsSignal = epics_signal_put_wait("PC_PULSE_INP")
-    pulse_width: EpicsSignal = epics_signal_put_wait("PC_PULSE_WID")
-    pulse_step: EpicsSignal = epics_signal_put_wait("PC_PULSE_STEP")
 
     dir: EpicsSignal = Component(EpicsSignal, "PC_DIR")
     arm_source: EpicsSignal = epics_signal_put_wait("PC_ARM_SEL")

--- a/src/artemis/devices/zebra.py
+++ b/src/artemis/devices/zebra.py
@@ -41,13 +41,25 @@ TTL_SHUTTER = 2
 TTL_XSPRESS3 = 3
 
 
+class I03_axes(Enum):
+    SMARGON_X1 = "Enc1"
+    SMARGON_Y = "Enc2"
+    SMARGON_Z = "Enc3"
+    OMEGA = "Enc4"
+
+
 class PositionCompare(Device):
     num_gates: EpicsSignal = epics_signal_put_wait("PC_GATE_NGATE")
+    gate_trigger: EpicsSignal = epics_signal_put_wait("PC_ENC")
     gate_source: EpicsSignal = epics_signal_put_wait("PC_GATE_SEL")
     gate_input: EpicsSignal = epics_signal_put_wait("PC_GATE_INP")
+    gate_width: EpicsSignal = epics_signal_put_wait("PC_GATE_WID")
+    gate_start: EpicsSignal = epics_signal_put_wait("PC_GATE_START")
 
     pulse_source: EpicsSignal = epics_signal_put_wait("PC_PULSE_SEL")
     pulse_input: EpicsSignal = epics_signal_put_wait("PC_PULSE_INP")
+    pulse_width: EpicsSignal = epics_signal_put_wait("PC_PULSE_WID")
+    pulse_step: EpicsSignal = epics_signal_put_wait("PC_PULSE_STEP")
 
     dir: EpicsSignal = Component(EpicsSignal, "PC_DIR")
     arm_source: EpicsSignal = epics_signal_put_wait("PC_ARM_SEL")
@@ -68,7 +80,7 @@ class PositionCompare(Device):
     def is_armed(self) -> bool:
         return self.armed.get() == 1
 
-    def arm_status(self, armed: int) -> StatusBase:
+    def arm_status(self, armed: int) -> SubscriptionStatus:
         return SubscriptionStatus(self.armed, lambda value, **_: value == armed)
 
 

--- a/src/artemis/system_tests/test_device_setups_and_cleanups.py
+++ b/src/artemis/system_tests/test_device_setups_and_cleanups.py
@@ -5,6 +5,7 @@ from artemis.device_setup_plans.setup_zebra_for_fgs import (
     set_zebra_shutter_to_manual,
     setup_zebra_for_fgs,
 )
+from artemis.device_setup_plans.setup_zebra_for_rotation import setup_zebra_for_rotation
 from artemis.devices.zebra import (
     IN3_TTL,
     IN4_TTL,
@@ -12,6 +13,7 @@ from artemis.devices.zebra import (
     PC_PULSE,
     TTL_DETECTOR,
     TTL_SHUTTER,
+    I03_axes,
     Zebra,
 )
 
@@ -22,11 +24,19 @@ def RE():
 
 
 @pytest.mark.s03
-def test_zebra_set_up(RE):
+def test_zebra_set_up_for_fgs(RE):
     zebra = Zebra(name="zebra", prefix="BL03S-EA-ZEBRA-01:")
     RE(setup_zebra_for_fgs(zebra))
     assert zebra.output.out_pvs[TTL_DETECTOR].get() == IN3_TTL
     assert zebra.output.out_pvs[TTL_SHUTTER].get() == IN4_TTL
+
+
+@pytest.mark.s03
+def test_zebra_set_up_for_rotation(RE):
+    zebra = Zebra(name="zebra", prefix="BL03S-EA-ZEBRA-01:")
+    RE(setup_zebra_for_rotation(zebra))
+    assert zebra.pc.gate_trigger.get(as_string=True) == I03_axes.OMEGA.value
+    assert zebra.pc.gate_width.get() == pytest.approx(360, 0.01)
 
 
 @pytest.mark.s03


### PR DESCRIPTION
Fixes #524 
Adds a plan which sets up the zebra for rotation data collection. Has been tested on the beamline.

### To test:
1. Run with S03 and check that the correct PVs are set to the correct values