### PR TITLE
Zocalo will now timeout if no results are recieved - Additionally tidies up some tests

### DIFF
--- a/src/artemis/devices/system_tests/test_aperturescatterguard_system.py
+++ b/src/artemis/devices/system_tests/test_aperturescatterguard_system.py
@@ -130,8 +130,6 @@ def test_aperturescatterguard_moves_in_correct_order(
     RE.subscribe(cb)
 
     ap_sg.wait_for_connection()
-    ap_sg.aperture.y.set(0, wait=True)
-    ap_sg.scatterguard.y.set(0, wait=True)
     ap_sg.aperture.z.set(pos1[2], wait=True)
 
     def monitor_and_moves():
@@ -139,9 +137,7 @@ def test_aperturescatterguard_moves_in_correct_order(
         yield from bps.monitor(ap_sg.aperture.y.motor_done_move, name="ap_y")
         yield from bps.monitor(ap_sg.scatterguard.y.motor_done_move, name="sg_y")
         yield from bps.mv(ap_sg, pos1)
-        yield from bps.sleep(0.05)
         yield from bps.mv(ap_sg, pos2)
-        yield from bps.sleep(0.05)
         yield from bps.close_run()
 
     RE(monitor_and_moves())

--- a/src/artemis/devices/unit_tests/test_eiger.py
+++ b/src/artemis/devices/unit_tests/test_eiger.py
@@ -120,8 +120,13 @@ def test_check_detector_variables(
 def test_when_set_odin_pvs_called_then_full_filename_written(fake_eiger: EigerDetector):
     expected_full_filename = f"{TEST_PREFIX}_{TEST_RUN_NUMBER}"
 
-    fake_eiger.set_odin_pvs()
+    status = fake_eiger.set_odin_pvs()
 
+    # Logic for propagating filename is not in fake eiger
+    fake_eiger.odin.meta.file_name.sim_put(expected_full_filename)
+    fake_eiger.odin.file_writer.id.sim_put(expected_full_filename)
+
+    status.wait()
     assert fake_eiger.odin.file_writer.file_name.get() == expected_full_filename
 
 

--- a/src/artemis/external_interaction/system_tests/conftest.py
+++ b/src/artemis/external_interaction/system_tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 from functools import partial
 from typing import Callable
 
@@ -7,6 +8,7 @@ from ispyb.sqlalchemy import DataCollection
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+import artemis.external_interaction.zocalo.zocalo_interaction
 from artemis.external_interaction.ispyb.store_in_ispyb import (
     StoreInIspyb2D,
     StoreInIspyb3D,
@@ -89,3 +91,9 @@ def dummy_ispyb(dummy_params) -> StoreInIspyb2D:
 @pytest.fixture
 def dummy_ispyb_3d(dummy_params) -> StoreInIspyb3D:
     return StoreInIspyb3D(ISPYB_CONFIG, dummy_params)
+
+
+@pytest.fixture
+def zocalo_env():
+    os.environ["ZOCALO_CONFIG"] = "/dls_sw/apps/zocalo/live/configuration.yaml"
+    artemis.external_interaction.zocalo.zocalo_interaction.TIMEOUT = 5

--- a/src/artemis/external_interaction/system_tests/test_zocalo_system.py
+++ b/src/artemis/external_interaction/system_tests/test_zocalo_system.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 
 from artemis.external_interaction.callbacks.fgs.fgs_callback_collection import (
@@ -8,11 +6,6 @@ from artemis.external_interaction.callbacks.fgs.fgs_callback_collection import (
 from artemis.external_interaction.callbacks.fgs.zocalo_callback import FGSZocaloCallback
 from artemis.external_interaction.system_tests.conftest import TEST_RESULT_LARGE
 from artemis.parameters import FullParameters, Point3D
-
-
-@pytest.fixture
-def zocalo_env():
-    os.environ["ZOCALO_CONFIG"] = "/dls_sw/apps/zocalo/live/configuration.yaml"
 
 
 @pytest.mark.s03

--- a/src/artemis/external_interaction/zocalo/zocalo_interaction.py
+++ b/src/artemis/external_interaction/zocalo/zocalo_interaction.py
@@ -1,6 +1,7 @@
 import getpass
 import queue
 import socket
+from datetime import datetime, timedelta
 from time import sleep
 from typing import Optional
 
@@ -32,7 +33,6 @@ class ZocaloInteractor:
 
         transport = lookup("PikaTransport")()
         transport.connect()
-
         return transport
 
     def _send_to_zocalo(self, parameters: dict):
@@ -81,7 +81,7 @@ class ZocaloInteractor:
         )
 
     def wait_for_result(
-        self, data_collection_group_id: int, timeout: int = TIMEOUT
+        self, data_collection_group_id: int, timeout: int = None
     ) -> Point3D:
         """Block until a result is received from Zocalo.
         Args:
@@ -107,6 +107,9 @@ class ZocaloInteractor:
                 ...
             ]
         """
+        # Set timeout default like this so that we can modify TIMEOUT during tests
+        if timeout is None:
+            timeout = TIMEOUT
         transport = self._get_zocalo_connection()
         result_received: queue.Queue = queue.Queue()
         exception: Optional[Exception] = None
@@ -143,8 +146,8 @@ class ZocaloInteractor:
         )
 
         try:
-            time_waited = 0
-            while time_waited < timeout:
+            start_time = datetime.now()
+            while datetime.now() - start_time < timedelta(seconds=timeout):
                 if result_received.empty():
                     if exception is not None:
                         raise exception

--- a/src/artemis/system_tests/test_fgs_plan.py
+++ b/src/artemis/system_tests/test_fgs_plan.py
@@ -1,4 +1,3 @@
-import os
 import uuid
 from typing import Callable
 from unittest.mock import MagicMock, patch
@@ -18,7 +17,10 @@ from artemis.experiment_plans.fast_grid_scan_plan import (
     run_gridscan,
 )
 from artemis.external_interaction.callbacks import FGSCallbackCollection
-from artemis.external_interaction.system_tests.conftest import fetch_comment  # noqa
+from artemis.external_interaction.system_tests.conftest import (  # noqa
+    fetch_comment,
+    zocalo_env,
+)
 from artemis.external_interaction.system_tests.test_ispyb_dev_connection import (
     ISPYB_CONFIG,
 )
@@ -30,11 +32,6 @@ from artemis.parameters import (
     FullParameters,
     GDABeamlineParameters,
 )
-
-
-@pytest.fixture
-def zocalo_env():
-    os.environ["ZOCALO_CONFIG"] = "/dls_sw/apps/zocalo/live/configuration.yaml"
 
 
 @pytest.fixture()
@@ -128,7 +125,6 @@ def test_read_hardware_for_ispyb(
     RE: RunEngine,
     fgs_composite: FGSComposite,
 ):
-
     undulator = fgs_composite.undulator
     synchrotron = fgs_composite.synchrotron
     slit_gaps = fgs_composite.slit_gaps


### PR DESCRIPTION
Fixes #545

### To test:
1. Run system tests without fake_zocalo running
2. Confirm it times out after ~5 secs
3. Confirm `test_when_set_odin_pvs_called_then_full_filename_written` is less flaky
4. Confirm aperture/scatterguard tests are faster (can do this by running just these tests on main and here, I see ~60 sec speedup)
