### PR TITLE
Add data collection group id to logs

### DIFF
--- a/src/artemis/external_interaction/callbacks/fgs/ispyb_callback.py
+++ b/src/artemis/external_interaction/callbacks/fgs/ispyb_callback.py
@@ -8,7 +8,7 @@ from artemis.external_interaction.ispyb.store_in_ispyb import (
     StoreInIspyb2D,
     StoreInIspyb3D,
 )
-from artemis.log import LOGGER
+from artemis.log import LOGGER, set_dcgid_tag
 from artemis.parameters import ISPYB_PLAN_NAME, SIM_ISPYB_CONFIG, FullParameters
 
 
@@ -74,6 +74,7 @@ class FGSISPyBHandlerCallback(CallbackBase):
 
             LOGGER.info("Creating ispyb entry.")
             self.ispyb_ids = self.ispyb.begin_deposition()
+            set_dcgid_tag(self.ispyb_ids[2])
 
     def stop(self, doc: dict):
         if doc.get("run_start") == self.uid_to_finalize_on:
@@ -83,3 +84,4 @@ class FGSISPyBHandlerCallback(CallbackBase):
             if self.ispyb_ids == (None, None, None):
                 raise ISPyBDepositionNotMade("ispyb was not initialised at run start")
             self.ispyb.end_deposition(exit_status, reason)
+            set_dcgid_tag(None)

--- a/src/artemis/external_interaction/callbacks/fgs/tests/test_ispyb_handler.py
+++ b/src/artemis/external_interaction/callbacks/fgs/tests/test_ispyb_handler.py
@@ -1,9 +1,13 @@
+import logging
 from unittest.mock import MagicMock, call
+
+import pytest
 
 from artemis.external_interaction.callbacks.fgs.ispyb_callback import (
     FGSISPyBHandlerCallback,
 )
 from artemis.external_interaction.callbacks.fgs.tests.conftest import TestData
+from artemis.log import LOGGER, set_up_logging_handlers
 from artemis.parameters import FullParameters
 
 DC_IDS = [1, 2]
@@ -15,9 +19,7 @@ def test_fgs_failing_results_in_bad_run_status_in_ispyb(
     mock_ispyb_update_time_and_status: MagicMock,
     mock_ispyb_get_time: MagicMock,
     mock_ispyb_store_grid_scan: MagicMock,
-    nexus_writer: MagicMock,
 ):
-
     mock_ispyb_store_grid_scan.return_value = [DC_IDS, None, DCG_ID]
     mock_ispyb_get_time.return_value = td.DUMMY_TIME_STRING
     mock_ispyb_update_time_and_status.return_value = None
@@ -47,9 +49,7 @@ def test_fgs_raising_no_exception_results_in_good_run_status_in_ispyb(
     mock_ispyb_update_time_and_status: MagicMock,
     mock_ispyb_get_time: MagicMock,
     mock_ispyb_store_grid_scan: MagicMock,
-    nexus_writer: MagicMock,
 ):
-
     mock_ispyb_store_grid_scan.return_value = [DC_IDS, None, DCG_ID]
     mock_ispyb_get_time.return_value = td.DUMMY_TIME_STRING
     mock_ispyb_update_time_and_status.return_value = None
@@ -68,3 +68,57 @@ def test_fgs_raising_no_exception_results_in_good_run_status_in_ispyb(
         ]
     )
     assert mock_ispyb_update_time_and_status.call_count == len(DC_IDS)
+
+
+@pytest.fixture
+def mock_emit():
+    set_up_logging_handlers(dev_mode=True)
+    test_handler = logging.Handler()
+    test_handler.emit = MagicMock()  # type: ignore
+    LOGGER.addHandler(test_handler)
+
+    yield test_handler.emit
+
+    LOGGER.removeHandler(test_handler)
+
+
+def test_given_ispyb_callback_started_writing_to_ispyb_when_messages_logged_then_they_contain_dcgid(
+    mock_emit, mock_ispyb_store_grid_scan: MagicMock
+):
+    mock_ispyb_store_grid_scan.return_value = [DC_IDS, None, DCG_ID]
+
+    params = FullParameters()
+    ispyb_handler = FGSISPyBHandlerCallback(params)
+
+    ispyb_handler.start(td.test_start_document)
+    ispyb_handler.descriptor(td.test_descriptor_document)
+    ispyb_handler.event(td.test_event_document)
+
+    LOGGER.info("test")
+
+    latest_record = mock_emit.call_args.args[0]
+    assert latest_record.dc_group_id == DCG_ID
+
+
+def test_given_ispyb_callback_finished_writing_to_ispyb_when_messages_logged_then_they_do_not_contain_dcgid(
+    mock_emit,
+    mock_ispyb_store_grid_scan: MagicMock,
+    mock_ispyb_update_time_and_status: MagicMock,
+    mock_ispyb_get_time: MagicMock,
+):
+    mock_ispyb_store_grid_scan.return_value = [DC_IDS, None, DCG_ID]
+    mock_ispyb_get_time.return_value = td.DUMMY_TIME_STRING
+    mock_ispyb_update_time_and_status.return_value = None
+
+    params = FullParameters()
+    ispyb_handler = FGSISPyBHandlerCallback(params)
+
+    ispyb_handler.start(td.test_start_document)
+    ispyb_handler.descriptor(td.test_descriptor_document)
+    ispyb_handler.event(td.test_event_document)
+    ispyb_handler.stop(td.test_run_gridscan_stop_document)
+
+    LOGGER.info("test")
+
+    latest_record = mock_emit.call_args.args[0]
+    assert not hasattr(latest_record, "dc_group_id")

--- a/src/artemis/external_interaction/ispyb/store_in_ispyb.py
+++ b/src/artemis/external_interaction/ispyb/store_in_ispyb.py
@@ -8,7 +8,7 @@ from sqlalchemy.connectors import Connector
 
 import artemis.devices.oav.utils as oav_utils
 from artemis.external_interaction.ispyb.ispyb_dataclass import Orientation
-from artemis.log import LOGGER
+from artemis.log import LOGGER, set_dcgid_tag
 from artemis.parameters import FullParameters
 from artemis.tracing import TRACER
 from artemis.utils import Point2D
@@ -49,6 +49,7 @@ class StoreInIspyb(ABC):
             self.grid_ids,
             self.datacollection_group_id,
         ) = self.store_grid_scan(self.full_params)
+        set_dcgid_tag(self.datacollection_group_id)
         return self.datacollection_ids, self.grid_ids, self.datacollection_group_id
 
     def end_deposition(self, success: str, reason: str):
@@ -61,6 +62,7 @@ class StoreInIspyb(ABC):
         LOGGER.info(
             f"End ispyb deposition with status '{success}' and reason '{reason}'."
         )
+        set_dcgid_tag(None)
         if success == "fail":
             run_status = "DataCollection Unsuccessful"
         elif success == "abort":

--- a/src/artemis/external_interaction/ispyb/store_in_ispyb.py
+++ b/src/artemis/external_interaction/ispyb/store_in_ispyb.py
@@ -8,7 +8,7 @@ from sqlalchemy.connectors import Connector
 
 import artemis.devices.oav.utils as oav_utils
 from artemis.external_interaction.ispyb.ispyb_dataclass import Orientation
-from artemis.log import LOGGER, set_dcgid_tag
+from artemis.log import LOGGER
 from artemis.parameters import FullParameters
 from artemis.tracing import TRACER
 from artemis.utils import Point2D
@@ -18,7 +18,6 @@ EIGER_FILE_SUFFIX = "h5"
 
 
 class StoreInIspyb(ABC):
-
     VISIT_PATH_REGEX = r".+/([a-zA-Z]{2}\d{4,5}-\d{1,3})/"
 
     def __init__(self, ispyb_config, parameters=None):
@@ -49,7 +48,6 @@ class StoreInIspyb(ABC):
             self.grid_ids,
             self.datacollection_group_id,
         ) = self.store_grid_scan(self.full_params)
-        set_dcgid_tag(self.datacollection_group_id)
         return self.datacollection_ids, self.grid_ids, self.datacollection_group_id
 
     def end_deposition(self, success: str, reason: str):
@@ -62,7 +60,6 @@ class StoreInIspyb(ABC):
         LOGGER.info(
             f"End ispyb deposition with status '{success}' and reason '{reason}'."
         )
-        set_dcgid_tag(None)
         if success == "fail":
             run_status = "DataCollection Unsuccessful"
         elif success == "abort":
@@ -76,7 +73,6 @@ class StoreInIspyb(ABC):
             )
 
     def store_grid_scan(self, full_params: FullParameters):
-
         self.full_params = full_params
         self.ispyb_params = full_params.ispyb_params
         self.detector_params = full_params.detector_params
@@ -116,7 +112,6 @@ class StoreInIspyb(ABC):
         datacollection_id: int,
         datacollection_group_id: int,
     ) -> None:
-
         if reason is not None and reason != "":
             self.append_to_comment(datacollection_id, f"{run_status} reason: {reason}")
 

--- a/src/artemis/log.py
+++ b/src/artemis/log.py
@@ -36,6 +36,8 @@ dc_group_id_filter = DCGIDFilter()
 
 
 def set_dcgid_tag(dcgid):
+    """Set the datacollection group id as a tag on all subsequent log messages.
+    Setting to None will remove the tag."""
     dc_group_id_filter.dc_group_id = dcgid
 
 

--- a/src/artemis/log.py
+++ b/src/artemis/log.py
@@ -1,7 +1,7 @@
 import logging
 from os import environ
 from pathlib import Path
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 from bluesky.log import config_bluesky_logging
 from bluesky.log import logger as bluesky_logger
@@ -21,6 +21,22 @@ class BeamlineFilter(logging.Filter):
     def filter(self, record):
         record.beamline = beamline if beamline else "dev"
         return True
+
+
+class DCGIDFilter(logging.Filter):
+    dc_group_id: Optional[str] = None
+
+    def filter(self, record):
+        if self.dc_group_id:
+            record.dc_group_id = self.dc_group_id
+        return True
+
+
+dc_group_id_filter = DCGIDFilter()
+
+
+def set_dcgid_tag(dcgid):
+    dc_group_id_filter.dc_group_id = dcgid
 
 
 def set_up_logging_handlers(
@@ -47,6 +63,7 @@ def set_up_logging_handlers(
         LOGGER.addHandler(handler)
 
     LOGGER.addFilter(BeamlineFilter())
+    LOGGER.addFilter(dc_group_id_filter)
 
     # for assistance in debugging
     if dev_mode:


### PR DESCRIPTION
Fixes #541

### To test:
1. Confirm unit tests pass
2. Confirm messages in graylog have group id, e.g. https://graylog2.diamond.ac.uk/messages/logs_8179/ee540061-b3d2-11ed-bee7-1866dafae904
