### PR TITLE
Stops unit tests pushing to real graylog

### DIFF
--- a/fake_zocalo/dls_start_fake_zocalo.sh
+++ b/fake_zocalo/dls_start_fake_zocalo.sh
@@ -7,7 +7,7 @@ activemq-for-dummy stop
 # starts the rabbitmq server and generates some credentials in ~/.fake_zocalo
 module load rabbitmq/dev
 
-# allows the `devrmq` zocalo environment to be used
+# allows the `dev_artemis` zocalo environment to be used
 module load dials/latest
 
 source .venv/bin/activate

--- a/src/artemis/parameters/constants.py
+++ b/src/artemis/parameters/constants.py
@@ -3,7 +3,7 @@ from enum import Enum
 SIM_BEAMLINE = "BL03S"
 SIM_INSERTION_PREFIX = "SR03S"
 ISPYB_PLAN_NAME = "ispyb_readings"
-SIM_ZOCALO_ENV = "devrmq"
+SIM_ZOCALO_ENV = "dev_artemis"
 DEFAULT_EXPERIMENT_TYPE = "grid_scan"
 I03_BEAMLINE_PARAMETER_PATH = (
     "/dls_sw/i03/software/daq_configuration/domain/beamlineParameters"

--- a/src/artemis/parameters/tests/test_data/good_test_rotation_scan_parameters.json
+++ b/src/artemis/parameters/tests/test_data/good_test_rotation_scan_parameters.json
@@ -3,7 +3,7 @@
     "artemis_params": {
         "beamline": "BL03S",
         "detector": "EIGER2_X_16M",
-        "zocalo_environment": "devrmq",
+        "zocalo_environment": "dev_artemis",
         "experiment_type": "rotation_scan",
         "detector_params": {
             "current_energy": 100,

--- a/test_parameters.json
+++ b/test_parameters.json
@@ -3,7 +3,7 @@
     "artemis_params": {
         "beamline": "BL03S",
         "detector": "EIGER2_X_16M",
-        "zocalo_environment": "devrmq",
+        "zocalo_environment": "dev_artemis",
         "experiment_type": "fast_grid_scan",
         "detector_params": {
             "current_energy": 100,


### PR DESCRIPTION
Fixes #556

### To test:
1. On main run the system tests and search on graylog with your machine name e.g. https://graylog2.diamond.ac.uk/search?rangetype=relative&fields=message%2Csource&width=1920&highlightMessage=&relative=7200&q=ws455
2. Confirm logs are getting sent to graylog
3. Switch to this branch
4. Clone https://gitlab.diamond.ac.uk/scisoft/zocalo/-/merge_requests/82 somewhere locally
5. In `zocalo_interaction.py` pass the modified config yaml e.g. `zc = zocalo.configuration.from_file("/scratch/ffv81422/zocalo/configuration.yaml")`
6. Repeat 1) and confirm no logging is happening anymore
