### PR TITLE
Set up dev tools to more easily work with dodal

### DIFF
--- a/.vscode/python-artemis.code-workspace
+++ b/.vscode/python-artemis.code-workspace
@@ -9,6 +9,7 @@
 	],
 	"settings": {
 		"python.languageServer": "Pylance",
-		"terminal.integrated.gpuAcceleration": "off"
+		"terminal.integrated.gpuAcceleration": "off",
+		"esbonio.sphinx.confDir": ""
 	}
 }

--- a/.vscode/python-artemis.code-workspace
+++ b/.vscode/python-artemis.code-workspace
@@ -1,0 +1,14 @@
+{
+	"folders": [
+		{
+			"path": ".."
+		},
+		{
+			"path": "../../dodal"
+		}
+	],
+	"settings": {
+		"python.languageServer": "Pylance",
+		"terminal.integrated.gpuAcceleration": "off"
+	}
+}

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Development Installation
 
 Run `dls_dev_env.sh` (This assumes you're on a DLS machine, if you are not you sould be able to just run a subset of this script)
 
+Note that because Artemis makes heavy use of [Dodal](https://github.com/DiamondLightSource/dodal) this will also pull a local editable version of dodal to the parent folder of this repo.
+
 Controlling the Gridscan Externally (e.g. from GDA)
 =====================
 

--- a/dls_dev_env.sh
+++ b/dls_dev_env.sh
@@ -13,6 +13,12 @@ mkdir .venv
 
 python -m venv .venv
 source .venv/bin/activate
+
+if [ ! -d "../dodal" ]; then
+  git clone git@github.com:DiamondLightSource/dodal.git ../dodal
+fi
+
+pip install -e ../dodal[dev]
 pip install -e .[dev]
 
 # get dlstbx into our env

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,4 +1,6 @@
-Fixes #(issue)
+Fixes #ISSUE
+
+Link to dodal PR (if required): #XXX
 
 ### To test:
 1. Do thing x

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     xarray
     doct
     databroker
-    dodal @ git+https://github.com/DiamondLightSource/python-dodal.git@9aa34f8db297e42ca6f741795c5d2782f8cf7040
+    dodal
 
 [options.extras_require]
 dev =

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     xarray
     doct
     databroker
-    dodal
+    dodal @ git+https://github.com/DiamondLightSource/python-dodal.git
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Fixes #558

Also modifyed docs in https://github.com/DiamondLightSource/python-artemis/wiki/Getting-Started (note new way of running vscode and message on having to select interpretter).

See also updated release docs in https://github.com/DiamondLightSource/python-artemis/wiki/Creating-a-release-and-deploying-it. Ensure that this process sounds sensible

After this is merged we should stop using `dls_dev_env.sh` to install to production. We can either make a new issue or modify https://github.com/DiamondLightSource/python-artemis/pull/466.

### To test:
1. Run `dls_dev_env.sh`
2. Run `code .vscode/python-artemis.code-workspace` and confirm a vscode session opens which works as expected
