### PR TITLE
Actually check the state of Artemis when running

### DIFF
--- a/run_artemis.sh
+++ b/run_artemis.sh
@@ -149,13 +149,15 @@ if [[ $START == 1 ]]; then
     RELATIVE_SCRIPT_DIR=$( dirname -- "$0"; )
     cd ${RELATIVE_SCRIPT_DIR}
 
-    if [ -n "$ARTEMIS_LOG_DIR" ]; then
+    if [ -z "$ARTEMIS_LOG_DIR" ]; then
         if [ $IN_DEV == true ]; then
             ARTEMIS_LOG_DIR=$RELATIVE_SCRIPT_DIR/tmp/dev
         else
             ARTEMIS_LOG_DIR=/dls_sw/$BEAMLINE/logs/bluesky
         fi
     fi
+    echo "Logging to $ARTEMIS_LOG_DIR"
+
     mkdir -p $ARTEMIS_LOG_DIR
     start_log_path=$ARTEMIS_LOG_DIR/start_log.txt
 

--- a/run_artemis.sh
+++ b/run_artemis.sh
@@ -149,14 +149,35 @@ if [[ $START == 1 ]]; then
     RELATIVE_SCRIPT_DIR=$( dirname -- "$0"; )
     cd ${RELATIVE_SCRIPT_DIR}
 
+    if [ $IN_DEV == true ]; then
+        log_path=$RELATIVE_SCRIPT_DIR/start_log.txt
+    else
+        log_path=/dls_sw/i03/logs/bluesky/start_log.txt
+    fi
+
     source .venv/bin/activate
-    python -m artemis `if [ $IN_DEV == true ]; then echo "--dev"; fi` >/dev/null 2>&1 &
+
+    python -m artemis `if [ $IN_DEV == true ]; then echo "--dev"; fi` >$log_path 2>&1 &
 
     echo "Waiting for Artemis to boot"
 
-    curl --head -X GET --retry 5 --retry-connrefused --retry-delay 1 http://localhost:5005/fast_grid_scan/status >/dev/null 2>&1
+    for i in {1..10}
+    do
+        curl --head -X GET http://localhost:5005/fast_grid_scan/status >/dev/null
+        ret_value=$?
+        if [ $ret_value -ne 0 ]; then
+            sleep 1
+        else
+            break
+        fi
+    done
 
-    echo "Artemis started"
+    if [ $ret_value -ne 0 ]; then
+        echo "Artemis Failed to start!!!!"
+        exit 1
+    else
+        echo "Artemis started"
+    fi
 fi
 
 sleep 1

--- a/run_artemis.sh
+++ b/run_artemis.sh
@@ -150,9 +150,9 @@ if [[ $START == 1 ]]; then
     cd ${RELATIVE_SCRIPT_DIR}
 
     if [ $IN_DEV == true ]; then
-        log_path=$RELATIVE_SCRIPT_DIR/start_log.txt
+        log_path=$RELATIVE_SCRIPT_DIR/tmp/dev/start_log.txt
     else
-        log_path=/dls_sw/i03/logs/bluesky/start_log.txt
+        log_path=/dls_sw/$BEAMLINE/logs/bluesky/start_log.txt
     fi
 
     source .venv/bin/activate

--- a/run_artemis.sh
+++ b/run_artemis.sh
@@ -149,21 +149,25 @@ if [[ $START == 1 ]]; then
     RELATIVE_SCRIPT_DIR=$( dirname -- "$0"; )
     cd ${RELATIVE_SCRIPT_DIR}
 
-    if [ $IN_DEV == true ]; then
-        log_path=$RELATIVE_SCRIPT_DIR/tmp/dev/start_log.txt
-    else
-        log_path=/dls_sw/$BEAMLINE/logs/bluesky/start_log.txt
+    if [ -n "$ARTEMIS_LOG_DIR" ]; then
+        if [ $IN_DEV == true ]; then
+            ARTEMIS_LOG_DIR=$RELATIVE_SCRIPT_DIR/tmp/dev
+        else
+            ARTEMIS_LOG_DIR=/dls_sw/$BEAMLINE/logs/bluesky
+        fi
     fi
+    mkdir -p $ARTEMIS_LOG_DIR
+    start_log_path=$ARTEMIS_LOG_DIR/start_log.txt
 
     source .venv/bin/activate
 
-    python -m artemis `if [ $IN_DEV == true ]; then echo "--dev"; fi` >$log_path 2>&1 &
+    python -m artemis `if [ $IN_DEV == true ]; then echo "--dev"; fi` >$start_log_path 2>&1 &
 
     echo "Waiting for Artemis to boot"
 
     for i in {1..10}
     do
-        curl --head -X GET http://localhost:5005/fast_grid_scan/status >/dev/null
+        curl --head -X GET http://localhost:5005/status >/dev/null
         ret_value=$?
         if [ $ret_value -ne 0 ]; then
             sleep 1

--- a/src/artemis/log.py
+++ b/src/artemis/log.py
@@ -102,17 +102,18 @@ def _get_graylog_configuration(dev_mode: bool) -> Tuple[str, int]:
 def _get_logging_file_path() -> Path:
     """Get the path to write the artemis log files to.
 
-    If on a beamline, this will be written to the according area depending on the
-    BEAMLINE envrionment variable. If no envrionment variable is found it will default
-    it to the tmp/dev directory.
+    If the ARTEMIS_LOG_DIR environment variable exists then logs will be put in here.
+
+    If no envrionment variable is found it will default it to the tmp/dev directory.
 
     Returns:
         logging_path (Path): Path to the log file for the file handler to write to.
     """
     logging_path: Path
 
-    if beamline:
-        logging_path = Path("/dls_sw/" + beamline + "/logs/bluesky/")
+    artemis_log_dir = environ.get("ARTEMIS_LOG_DIR")
+    if artemis_log_dir:
+        logging_path = Path(artemis_log_dir)
     else:
         logging_path = Path("./tmp/dev/")
 

--- a/src/artemis/unit_tests/test_log.py
+++ b/src/artemis/unit_tests/test_log.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -65,7 +66,7 @@ def test_prod_mode_sets_correct_graypy_handler(
 
 @patch("artemis.log.GELFTCPHandler")
 @patch("artemis.log.logging")
-def test_dev_mode_sets_correct_file_handler(
+def test_no_env_variable_sets_correct_file_handler(
     mock_logging,
     mock_GELFTCPHandler,
     mock_logger: MagicMock,
@@ -79,13 +80,13 @@ def test_dev_mode_sets_correct_file_handler(
 @patch("artemis.log.Path.mkdir")
 @patch("artemis.log.GELFTCPHandler")
 @patch("artemis.log.logging")
-def test_prod_mode_sets_correct_file_handler(
+@patch.dict(os.environ, {"ARTEMIS_LOG_DIR": "/dls_sw/s03/logs/bluesky"})
+def test_set_env_variable_sets_correct_file_handler(
     mock_logging,
     mock_GELFTCPHandler,
     mock_dir,
     mock_logger: MagicMock,
 ):
-    log.beamline = "s03"
     log.set_up_logging_handlers(None, False)
     mock_logging.FileHandler.assert_called_once_with(
         filename=Path("/dls_sw/s03/logs/bluesky/artemis.txt")


### PR DESCRIPTION
Fixes #497

Needs GDA changes in https://gerrit.diamond.ac.uk/c/gda/gda-mx/+/38534

### To test:
1. Add `raise Exception()` in the first line of `__main__.py`, this will cause Artemis to not be able to start
2. Confirm `run_artemis.sh` fails and produces nice logs in `./tmp/dev`
3. Run `artemis_restart()` on the jython console and when prompted give the path to your local artemis
4. Confirm with the error introduced in 1 it bombs out and that the logs are in the location GDA says they are
6. Remove the error in 1 and confirm `artemis_restart` is happy again