### PR TITLE
Add reminder to PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,7 @@
 Fixes #ISSUE
 
 Link to dodal PR (if required): #XXX
+(remember to update setupd.cfg with the dodal commit tag if you need it for tests to pass!)
 
 ### To test:
 1. Do thing x


### PR DESCRIPTION
Fixes #586 

Adds a reminder to update artemis dependencies for pull requests with the commit of dodal if necessary