### PR TITLE
Added error message and logging for invalid json parameters, and tests

### DIFF
--- a/src/artemis/parameters/external_parameters.py
+++ b/src/artemis/parameters/external_parameters.py
@@ -8,8 +8,10 @@ from typing import Dict, Optional, Type, Union
 
 import jsonschema
 from dataclasses_json import DataClassJsonMixin
+from jsonschema.exceptions import ValidationError
 
 import artemis.experiment_plans.experiment_registry as registry
+import artemis.log
 from artemis.parameters.constants import (
     PARAMETER_VERSION,
     SIM_BEAMLINE,
@@ -169,8 +171,12 @@ class RawParameters:
             base_uri=f"{path.as_uri()}/",
             referrer=True,
         )
-        # TODO improve failed validation error messages
-        jsonschema.validate(dict_params, full_schema, resolver=resolver)
+        try:
+            jsonschema.validate(dict_params, full_schema, resolver=resolver)
+        except ValidationError:
+            artemis.log.LOGGER.error("Invalid json parameters")
+            raise ValidationError("Invalid Json parameters")
+
         experiment_type = EXTERNAL_EXPERIMENT_PARAM_DICT.get(
             dict_params["artemis_params"]["experiment_type"]
         )

--- a/src/artemis/system_tests/test_main_system.py
+++ b/src/artemis/system_tests/test_main_system.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from flask.testing import FlaskClient
+from jsonschema.exceptions import ValidationError
 
 from artemis.__main__ import Actions, BlueskyRunner, Status, cli_arg_parse, create_app
 from artemis.experiment_plans.experiment_registry import PLAN_REGISTRY
@@ -209,3 +210,9 @@ def test_when_blueskyrunner_initiated_then_plans_are_setup_and_devices_connected
     BlueskyRunner(MagicMock())
 
     mock_fgs.return_value.wait_for_connection.assert_called_once()
+
+
+def test_error_and_log_on_invalid_json_params(caplog, test_env: ClientAndRunEngine):
+    with pytest.raises(ValidationError):
+        test_env.client.put(START_ENDPOINT, data='{"bad":1}')
+    assert "Invalid json parameters" in caplog.text


### PR DESCRIPTION
Fixes #596

### To test:
1. Run new tests in test_main_system.py
2. Run `curl -X PUT http://127.0.0.1:5005/fast_grid_scan/start -H "Content-Type: application/json" --data "{\"bad\":1}" `and confirm error message is printed as well as logged in tmp/dev/artemis.txt
