### PR TITLE
Updated zocalo message format

### DIFF
--- a/fake_zocalo/__main__.py
+++ b/fake_zocalo/__main__.py
@@ -52,7 +52,7 @@ def get_dcgid_and_prefix(dcid: int, Session) -> Tuple[int, str]:
 def make_result(payload):
     res = {
         "environment": {"ID": "6261b482-bef2-49f5-8699-eb274cd3b92e"},
-        "payload": payload,
+        "payload": {"results": payload},
         "recipe": {
             "start": [[1, payload]],
             "1": {

--- a/src/artemis/external_interaction/unit_tests/test_zocalo_interaction.py
+++ b/src/artemis/external_interaction/unit_tests/test_zocalo_interaction.py
@@ -105,12 +105,14 @@ def test_when_message_recieved_from_zocalo_then_point_returned(
     zc = ZocaloInteractor(environment=SIM_ZOCALO_ENV)
     centre_of_mass_coords = [2.942925659754348, 7.142683401382778, 6.79110544979448]
 
-    message = [
-        {
-            "max_voxel": [3, 5, 5],
-            "centre_of_mass": centre_of_mass_coords,
-        }
-    ]
+    message = {
+        "results": [
+            {
+                "max_voxel": [3, 5, 5],
+                "centre_of_mass": centre_of_mass_coords,
+            }
+        ]
+    }
     datacollection_grid_id = 7263143
     step_params = {"dcid": "8183741", "dcgid": str(datacollection_grid_id)}
 
@@ -186,7 +188,7 @@ def test_when_no_results_returned_then_no_diffraction_exception_raised(
 ):
     zc = ZocaloInteractor(environment=SIM_ZOCALO_ENV)
 
-    message = []
+    message = {}
     datacollection_grid_id = 7263143
     step_params = {"dcid": "8183741", "dcgid": str(datacollection_grid_id)}
 

--- a/src/artemis/external_interaction/zocalo/zocalo_interaction.py
+++ b/src/artemis/external_interaction/zocalo/zocalo_interaction.py
@@ -92,20 +92,22 @@ class ZocaloInteractor:
         Returns:
             Returns the message from zocalo, as a list of dicts describing each crystal
             which zocalo found:
-            [
-                {
-                    "centre_of_mass": [1, 2, 3],
-                    "max_voxel": [2, 4, 5],
-                    "max_count": 105062,
-                    "n_voxels": 35,
-                    "total_count": 2387574,
-                    "bounding_box": [[1, 2, 3], [3, 4, 4]],
-                },
-                {
-                    result 2
-                },
-                ...
-            ]
+            {
+                "results": [
+                    {
+                        "centre_of_mass": [1, 2, 3],
+                        "max_voxel": [2, 4, 5],
+                        "max_count": 105062,
+                        "n_voxels": 35,
+                        "total_count": 2387574,
+                        "bounding_box": [[1, 2, 3], [3, 4, 4]],
+                    },
+                    {
+                        result 2
+                    },
+                    ...
+                ]
+            }
         """
         # Set timeout default like this so that we can modify TIMEOUT during tests
         if timeout is None:
@@ -124,9 +126,10 @@ class ZocaloInteractor:
                 transport.ack(header)
                 received_group_id = recipe_parameters["dcgid"]
                 if received_group_id == str(data_collection_group_id):
-                    if len(message) == 0:
+                    results = message.get("results", [])
+                    if len(results) == 0:
                         raise NoDiffractionFound()
-                    result_received.put(message)
+                    result_received.put(results)
                 else:
                     artemis.log.LOGGER.warning(
                         f"Warning: results for {received_group_id} received but expected \


### PR DESCRIPTION
See https://github.com/DiamondLightSource/python-dlstbx/pull/215
### To test:
1. Do grid scan
2. Confirm artemis correctly handles the new format of XRC result returned by zocalo
