### PR TITLE
delete logging handlers in global test teardown

### DIFF
--- a/src/artemis/conftest.py
+++ b/src/artemis/conftest.py
@@ -5,6 +5,12 @@ from os import environ, getenv
 def pytest_runtest_teardown():
     if "dodal.i03" in sys.modules:
         sys.modules["dodal.i03"].clear_devices()
+    if "artemis.log" in sys.modules:
+        artemis_log = sys.modules["artemis.log"]
+        [artemis_log.LOGGER.removeHandler(h) for h in artemis_log.LOGGER.handlers]
+    if "dodal.log" in sys.modules:
+        dodal_log = sys.modules["dodal.log"]
+        [dodal_log.LOGGER.removeHandler(h) for h in dodal_log.LOGGER.handlers]
 
 
 s03_epics_server_port = getenv("S03_EPICS_CA_SERVER_PORT")

--- a/src/artemis/unit_tests/test_log.py
+++ b/src/artemis/unit_tests/test_log.py
@@ -22,7 +22,6 @@ def clear_loggers():
     [dodal_logger.removeHandler(h) for h in dodal_logger.handlers]
 
 
-@pytest.mark.skip(reason="to be fixed in #644")
 @patch("dodal.log.config_bluesky_logging")
 @patch("dodal.log.config_ophyd_logging")
 def test_no_env_variable_sets_correct_file_handler(
@@ -38,7 +37,6 @@ def test_no_env_variable_sets_correct_file_handler(
     assert file_handlers.baseFilename.endswith("/tmp/dev/artemis.txt")
 
 
-@pytest.mark.skip(reason="to be fixed in #644")
 @patch("artemis.log.Path.mkdir")
 @patch.dict(
     os.environ, {"ARTEMIS_LOG_DIR": "./dls_sw/s03/logs/bluesky"}
@@ -56,7 +54,6 @@ def test_set_env_variable_sets_correct_file_handler(
     assert file_handlers.baseFilename.endswith("/dls_sw/s03/logs/bluesky/artemis.txt")
 
 
-@pytest.mark.skip(reason="to be fixed in #644")
 def test_messages_logged_from_dodal_and_artemis_contain_dcgid(
     clear_loggers,
 ):


### PR DESCRIPTION
and uncomment tests

Fixes #644

### To test:
1. see tests work I guess?
