### PR TITLE
678 pydantic internal params

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     xarray
     doct
     databroker
-    dodal @ git+https://github.com/DiamondLightSource/python-dodal.git@6c63750e44096eb011b4722f702b4af29cc77cc1
+    dodal @ git+https://github.com/DiamondLightSource/python-dodal.git@2eaf95f9925aafb1568c12319772bdbf53d11765
 
 [options.extras_require]
 dev =

--- a/src/artemis/parameters/internal_parameters/internal_parameters.py
+++ b/src/artemis/parameters/internal_parameters/internal_parameters.py
@@ -1,8 +1,9 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict
+from typing import Any
 
 from dodal.devices.eiger import DetectorParams
 from dodal.parameters.experiment_parameter_base import AbstractExperimentParameterBase
+from pydantic import BaseModel
 
 import artemis.parameters.external_parameters as raw_parameters
 from artemis.external_interaction.ispyb.ispyb_dataclass import (
@@ -19,30 +20,13 @@ from artemis.parameters.constants import (
 from artemis.utils.utils import Point3D
 
 
-class ArtemisParameters:
+class ArtemisParameters(BaseModel):
     zocalo_environment: str = SIM_ZOCALO_ENV
     beamline: str = SIM_BEAMLINE
     insertion_prefix: str = SIM_INSERTION_PREFIX
     experiment_type: str = DEFAULT_EXPERIMENT_TYPE
-
     detector_params: DetectorParams = DetectorParams(**DETECTOR_PARAM_DEFAULTS)
     ispyb_params: IspybParams = IspybParams(**ISPYB_PARAM_DEFAULTS)
-
-    def __init__(
-        self,
-        zocalo_environment: str = SIM_ZOCALO_ENV,
-        beamline: str = SIM_BEAMLINE,
-        insertion_prefix: str = SIM_INSERTION_PREFIX,
-        experiment_type: str = DEFAULT_EXPERIMENT_TYPE,
-        detector_params: Dict[str, Any] = DETECTOR_PARAM_DEFAULTS,
-        ispyb_params: Dict[str, Any] = ISPYB_PARAM_DEFAULTS,
-    ) -> None:
-        self.zocalo_environment = zocalo_environment
-        self.beamline = beamline
-        self.insertion_prefix = insertion_prefix
-        self.experiment_type = experiment_type
-        self.detector_params: DetectorParams = DetectorParams(**detector_params)
-        self.ispyb_params: IspybParams = IspybParams(**ispyb_params)
 
     def __repr__(self):
         return (
@@ -209,4 +193,10 @@ class InternalParameters(ABC):
     def from_external_dict(cls, dict_data):
         """Convenience method to generate from external parameter dictionary, uses
         RawParameters.from_dict()"""
+        return cls(raw_parameters.validate_raw_parameters_from_dict(dict_data))
+
+    @classmethod
+    def from_internal_dict(cls, dict_data):
+        """Convenience method to generate from a dictionary generated from an
+        InternalParameters object."""
         return cls(raw_parameters.validate_raw_parameters_from_dict(dict_data))

--- a/src/artemis/parameters/internal_parameters/internal_parameters.py
+++ b/src/artemis/parameters/internal_parameters/internal_parameters.py
@@ -26,7 +26,7 @@ class ArtemisParameters:
     experiment_type: str = DEFAULT_EXPERIMENT_TYPE
 
     detector_params: DetectorParams = DetectorParams.from_dict(DETECTOR_PARAM_DEFAULTS)
-    ispyb_params: IspybParams = IspybParams.from_dict(ISPYB_PARAM_DEFAULTS)
+    ispyb_params: IspybParams = IspybParams(**ISPYB_PARAM_DEFAULTS)
 
     def __init__(
         self,
@@ -42,7 +42,7 @@ class ArtemisParameters:
         self.insertion_prefix = insertion_prefix
         self.experiment_type = experiment_type
         self.detector_params: DetectorParams = DetectorParams.from_dict(detector_params)
-        self.ispyb_params: IspybParams = IspybParams.from_dict(ispyb_params)
+        self.ispyb_params: IspybParams = IspybParams(**ispyb_params)
 
     def __repr__(self):
         return (

--- a/src/artemis/parameters/internal_parameters/internal_parameters.py
+++ b/src/artemis/parameters/internal_parameters/internal_parameters.py
@@ -25,7 +25,7 @@ class ArtemisParameters:
     insertion_prefix: str = SIM_INSERTION_PREFIX
     experiment_type: str = DEFAULT_EXPERIMENT_TYPE
 
-    detector_params: DetectorParams = DetectorParams.from_dict(DETECTOR_PARAM_DEFAULTS)
+    detector_params: DetectorParams = DetectorParams(**DETECTOR_PARAM_DEFAULTS)
     ispyb_params: IspybParams = IspybParams(**ISPYB_PARAM_DEFAULTS)
 
     def __init__(
@@ -41,7 +41,7 @@ class ArtemisParameters:
         self.beamline = beamline
         self.insertion_prefix = insertion_prefix
         self.experiment_type = experiment_type
-        self.detector_params: DetectorParams = DetectorParams.from_dict(detector_params)
+        self.detector_params: DetectorParams = DetectorParams(**detector_params)
         self.ispyb_params: IspybParams = IspybParams(**ispyb_params)
 
     def __repr__(self):


### PR DESCRIPTION
Fixes 678
Makes all the internal param classes into pydantic models. Does not yet do it for InternalParameters because that is more complicated - new issue for this: https://github.com/DiamondLightSource/python-artemis/issues/681

Link to dodal PR (if required): https://github.com/DiamondLightSource/dodal/pull/68

### To test:
1. Run tests
