### PR TITLE
Bump parameter version to 1.0.0

### DIFF
--- a/src/artemis/parameters/schemas/full_external_parameters_schema.json
+++ b/src/artemis/parameters/schemas/full_external_parameters_schema.json
@@ -3,7 +3,7 @@
     "type": "object",
     "properties": {
         "params_version": {
-            "const": "0.0.5"
+            "const": "1.0.0"
         },
         "artemis_params": {
             "type": "object",

--- a/src/artemis/parameters/tests/test_data/good_test_parameters.json
+++ b/src/artemis/parameters/tests/test_data/good_test_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "0.0.5",
+    "params_version": "1.0.0",
     "artemis_params": {
         "beamline": "BL03S",
         "detector": "EIGER2_X_16M",

--- a/src/artemis/parameters/tests/test_data/good_test_rotation_scan_parameters.json
+++ b/src/artemis/parameters/tests/test_data/good_test_rotation_scan_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "0.0.5",
+    "params_version": "1.0.0",
     "artemis_params": {
         "beamline": "BL03S",
         "detector": "EIGER2_X_16M",

--- a/test_parameter_defaults.json
+++ b/test_parameter_defaults.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "0.0.5",
+    "params_version": "1.0.0",
     "artemis_params": {
         "zocalo_environment": "dev_artemis",
         "beamline": "BL03S",

--- a/test_parameters.json
+++ b/test_parameters.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "0.0.5",
+    "params_version": "1.0.0",
     "artemis_params": {
         "beamline": "BL03S",
         "detector": "EIGER2_X_16M",


### PR DESCRIPTION

### To test:
1. Confirm unit tests are still passing
2. Confirm I haven't missed anywhere we're still referring to "0.0.5"
3. Run https://gerrit.diamond.ac.uk/c/gda/gda-mx/+/39272/1 against this branch and confirm you do not get a validation error on the parameter version (you will instead get https://github.com/DiamondLightSource/python-artemis/issues/718)