### PR TITLE
GDA should use exception status from Artemis to work out if to continue

### DIFF
--- a/src/artemis/system_tests/test_main_system.py
+++ b/src/artemis/system_tests/test_main_system.py
@@ -12,6 +12,7 @@ import pytest
 from flask.testing import FlaskClient
 
 from artemis.__main__ import Actions, BlueskyRunner, Status, cli_arg_parse, create_app
+from artemis.exceptions import WarningException
 from artemis.experiment_plans.experiment_registry import PLAN_REGISTRY
 from artemis.external_interaction.callbacks.abstract_plan_callback_collection import (
     AbstractPlanCallbackCollection,
@@ -31,19 +32,19 @@ TEST_PARAMS = json.dumps(external_parameters.from_file("test_parameter_defaults.
 class MockRunEngine:
     RE_takes_time = True
     aborting_takes_time = False
-    error: Optional[str] = None
+    error: Optional[Exception] = None
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:
         while self.RE_takes_time:
             sleep(0.1)
             if self.error:
-                raise Exception(self.error)
+                raise self.error
 
     def abort(self):
         while self.aborting_takes_time:
             sleep(0.1)
             if self.error:
-                raise Exception(self.error)
+                raise self.error
         self.RE_takes_time = False
 
     def subscribe(self, *args):
@@ -218,14 +219,16 @@ def test_given_started_when_stopped_and_started_again_then_runs(
 
 
 def test_given_started_when_RE_stops_on_its_own_with_error_then_error_reported(
+    caplog,
     test_env: ClientAndRunEngine,
 ):
     test_env.client.put(START_ENDPOINT, data=TEST_PARAMS)
-    error_message = "D'Oh"
-    test_env.mock_run_engine.error = error_message
+    test_env.mock_run_engine.error = Exception("D'Oh")
     response_json = wait_for_run_engine_status(test_env.client)
     assert response_json["status"] == Status.FAILED.value
     assert response_json["message"] == 'Exception("D\'Oh")'
+    assert response_json["exception_type"] == "Exception"
+    assert caplog.records[-1].levelname == "ERROR"
 
 
 def test_when_started_n_returnstatus_interrupted_bc_RE_aborted_thn_error_reptd(
@@ -233,14 +236,14 @@ def test_when_started_n_returnstatus_interrupted_bc_RE_aborted_thn_error_reptd(
 ):
     test_env.mock_run_engine.aborting_takes_time = True
     test_env.client.put(START_ENDPOINT, data=TEST_PARAMS)
-    error_message = "D'Oh"
     test_env.client.put(STOP_ENDPOINT)
-    test_env.mock_run_engine.error = error_message
+    test_env.mock_run_engine.error = Exception("D'Oh")
     response_json = wait_for_run_engine_status(
         test_env.client, lambda status: status != Status.ABORTING.value
     )
     assert response_json["status"] == Status.FAILED.value
     assert response_json["message"] == 'Exception("D\'Oh")'
+    assert response_json["exception_type"] == "Exception"
 
 
 def test_given_started_when_RE_stops_on_its_own_happily_then_no_error_reported(
@@ -422,7 +425,7 @@ def test_when_blueskyrunner_initiated_and_skip_flag_is_not_set_then_all_plans_se
         assert mock_setup.call_count == 4
 
 
-def test_log_on_invalid_json_params(caplog, test_env: ClientAndRunEngine):
+def test_log_on_invalid_json_params(test_env: ClientAndRunEngine):
     response = test_env.client.put(TEST_BAD_PARAM_ENDPOINT, data='{"bad":1}').json
     assert isinstance(response, dict)
     assert response.get("status") == Status.FAILED.value
@@ -430,4 +433,14 @@ def test_log_on_invalid_json_params(caplog, test_env: ClientAndRunEngine):
         response.get("message")
         == "<ValidationError: \"{'bad': 1} does not have enough properties\">"
     )
-    assert "Invalid json parameters" in caplog.text
+    assert response.get("exception_type") == "ValidationError"
+
+
+def test_warn_exception_during_plan_causes_warning_in_log(caplog, test_env):
+    test_env.client.put(START_ENDPOINT, data=TEST_PARAMS)
+    test_env.mock_run_engine.error = WarningException("D'Oh")
+    response_json = wait_for_run_engine_status(test_env.client)
+    assert response_json["status"] == Status.FAILED.value
+    assert response_json["message"] == 'WarningException("D\'Oh")'
+    assert response_json["exception_type"] == "WarningException"
+    assert caplog.records[-1].levelname == "WARNING"


### PR DESCRIPTION
Fixes #679

Note: this contains changes from https://github.com/DiamondLightSource/python-artemis/pull/722, that PR should be reviewed/merged first

The associated GDA change is https://gerrit.diamond.ac.uk/c/gda/gda-mx/+/39268/3, please +2 this at the same time.

### To test:
1. Confirm unit tests still all pass
2. Using the GDA change above set it up to talk to Artemis by adding the following properties:
```
gda.gridscan.artemis.enabled=true
gda.gridscan.artemis.grid.detection=true
gda.gridscan.artemis.flaskServerAddress=localhost:5005
gda.mx.callArtemisInDummyMode=true
```
3. Paste the following into the data collection table:
```
<?xml version="1.0" encoding="UTF-8"?>
<ExtendedCollectRequests>
    <usingDna>false</usingDna>
    <extendedCollectRequest>
        <collect_request>
            <fileinfo>
                <directory>/tmp/gda/i03/data/2023/cm33866-3/ssa</directory>
                <prefix>sdasda</prefix>
            </fileinfo>
            <oscillation_sequence>
                <start>0.0</start>
                <range>0.1</range>
                <number_of_images>100</number_of_images>
                <overlap>0.0</overlap>
                <exposure_time>0.01</exposure_time>
                <start_image_number>1</start_image_number>
                <number_of_passes>1</number_of_passes>
            </oscillation_sequence>
            <wavelength>0.97625</wavelength>
            <resolution>
                <upper>1.9780068845283907</upper>
            </resolution>
            <sample_reference>
                <code>NR</code>
                <container_reference>1</container_reference>
                <sample_location>1</sample_location>
            </sample_reference>
        </collect_request>
        <runNumber>0</runNumber>
        <sampleDetectorDistanceInMM>289.3</sampleDetectorDistanceInMM>
        <transmissionInPerCent>100.0</transmissionInPerCent>
        <sampleName>Hr: 1 Pos: 1</sampleName>
        <visitPath>/tmp/gda/i03/data/2023/cm33866-3</visitPath>
        <comment></comment>
        <centringMode>XRAY</centringMode>
        <experimentType>SAD</experimentType>
        <doseProtocol>target_exposure</doseProtocol>
        <totalNumberOfImages>100</totalNumberOfImages>
        <fileNameTemplate>/tmp/gda/i03/data/2023/cm33866-3/ssa/sdasda_0_%05d.%s</fileNameTemplate>
        <dnaFileNameTemplate>sdasda_0_#####.%s</dnaFileNameTemplate>
        <dnaFilePrefix>sdasda_0_</dnaFilePrefix>
        <dnaFileDir>/tmp/gda/i03/data/2023/cm33866-3/ssa</dnaFileDir>
        <hasTransmission>true</hasTransmission>
        <beamstopPosition>0</beamstopPosition>
        <chi>0.0</chi>
        <phi>0.0</phi>
        <omegaDelta>0.0</omegaDelta>
        <axisChoice>Omega</axisChoice>
        <beamProfile/>
    </extendedCollectRequest>
    <extendedCollectRequest>
        <collect_request>
            <fileinfo>
                <directory>/tmp/gda/i03/data/2023/cm33866-3/ssa</directory>
                <prefix>sdasda</prefix>
            </fileinfo>
            <oscillation_sequence>
                <start>0.0</start>
                <range>0.1</range>
                <number_of_images>100</number_of_images>
                <overlap>0.0</overlap>
                <exposure_time>0.01</exposure_time>
                <start_image_number>1</start_image_number>
                <number_of_passes>1</number_of_passes>
            </oscillation_sequence>
            <wavelength>0.97625</wavelength>
            <resolution>
                <upper>1.9780068845283907</upper>
            </resolution>
            <sample_reference>
                <code></code>
                <container_reference>35</container_reference>
                <sample_location>2</sample_location>
                <blSampleId>4288613</blSampleId>
            </sample_reference>
        </collect_request>
        <runNumber>0</runNumber>
        <sampleDetectorDistanceInMM>289.3</sampleDetectorDistanceInMM>
        <transmissionInPerCent>100.0</transmissionInPerCent>
        <sampleName>b2</sampleName>
        <visitPath>/tmp/gda/i03/data/2023/cm33866-3</visitPath>
        <comment></comment>
        <centringMode>XRAY</centringMode>
        <experimentType>SAD</experimentType>
        <doseProtocol>target_exposure</doseProtocol>
        <totalNumberOfImages>100</totalNumberOfImages>
        <fileNameTemplate>/tmp/gda/i03/data/2023/cm33866-3/ssa/sdasda_0_%05d.%s</fileNameTemplate>
        <dnaFileNameTemplate>sdasda_0_#####.%s</dnaFileNameTemplate>
        <dnaFilePrefix>sdasda_0_</dnaFilePrefix>
        <dnaFileDir>/tmp/gda/i03/data/2023/cm33866-3/ssa</dnaFileDir>
        <hasTransmission>true</hasTransmission>
        <beamstopPosition>0</beamstopPosition>
        <chi>0.0</chi>
        <phi>0.0</phi>
        <omegaDelta>0.0</omegaDelta>
        <axisChoice>Omega</axisChoice>
        <beamProfile/>
    </extendedCollectRequest>
</ExtendedCollectRequests>
```
4. With no s03 running start artemis with `./run_artemis.sh --skip-startup-connection`
5. Queue both collections in GDA, confirm the first grid scan fails catastrophically and the second data collection does not happen
6. Modify `full_grid_scan.py` to have:
```python
def create_devices():
    pass

def get_plan(
    parameters: GridScanWithEdgeDetectInternalParameters,
    subscriptions: FGSCallbackCollection,
    oav_param_files: dict = OAV_CONFIG_FILE_DEFAULTS,
) -> Callable:
    """
    A plan which combines the collection of snapshots from the OAV and the determination
    of the grid dimensions to use for the following grid scan.
    """
    from artemis.exceptions import WarningException

    raise WarningException("Don't stop!")
```
8. Restart Artemis
7. Queue the collections up again and confirm that you get the `Don't Stop` message in the GDA log but both collections happen