### PR TITLE
656 move callback creation to inside plan

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
     xarray
     doct
     databroker
+    dodal @ git+https://github.com/DiamondLightSource/python-dodal.git
 
 [options.extras_require]
 dev =

--- a/src/artemis/__main__.py
+++ b/src/artemis/__main__.py
@@ -14,7 +14,6 @@ from flask_restful import Api, Resource
 from jsonschema.exceptions import ValidationError
 
 import artemis.log
-from artemis.exceptions import WarningException
 from artemis.experiment_plans.experiment_registry import PLAN_REGISTRY, PlanNotFound
 from artemis.external_interaction.callbacks.aperture_change_callback import (
     ApertureChangeCallback,

--- a/src/artemis/__main__.py
+++ b/src/artemis/__main__.py
@@ -14,6 +14,7 @@ from flask_restful import Api, Resource
 from jsonschema.exceptions import ValidationError
 
 import artemis.log
+from artemis.exceptions import WarningException
 from artemis.experiment_plans.experiment_registry import PLAN_REGISTRY, PlanNotFound
 from artemis.external_interaction.callbacks.aperture_change_callback import (
     ApertureChangeCallback,
@@ -122,9 +123,9 @@ class BlueskyRunner:
                     )
 
                     self.last_run_aborted = False
-                # except WarningException as exception:
-                #    artemis.log.LOGGER.warning("Warning Exception", exc_info=True)
-                #    self.current_status = StatusAndMessage(Status.WARN, repr(exception))
+                except WarningException as exception:
+                    artemis.log.LOGGER.warning("Warning Exception", exc_info=True)
+                    self.current_status = StatusAndMessage(Status.WARN, repr(exception))
                 except Exception as exception:
                     artemis.log.LOGGER.error("Exception on running plan", exc_info=True)
 

--- a/src/artemis/experiment_plans/fast_grid_scan_plan.py
+++ b/src/artemis/experiment_plans/fast_grid_scan_plan.py
@@ -30,6 +30,9 @@ from artemis.device_setup_plans.setup_zebra import (
     setup_zebra_for_fgs,
 )
 from artemis.exceptions import WarningException
+from artemis.external_interaction.callbacks.fgs.fgs_callback_collection import (
+    FGSCallbackCollection,
+)
 from artemis.parameters import external_parameters
 from artemis.parameters.beamline_parameters import (
     get_beamline_parameters,
@@ -39,9 +42,6 @@ from artemis.parameters.constants import ISPYB_PLAN_NAME, SIM_BEAMLINE
 from artemis.tracing import TRACER
 
 if TYPE_CHECKING:
-    from artemis.external_interaction.callbacks.fgs.fgs_callback_collection import (
-        FGSCallbackCollection,
-    )
     from artemis.parameters.plan_specific.fgs_internal_params import (
         FGSInternalParameters,
     )
@@ -284,7 +284,6 @@ def run_gridscan_and_move(
 
 def get_plan(
     parameters: FGSInternalParameters,
-    subscriptions: FGSCallbackCollection,
 ) -> Callable:
     """Create the plan to run the grid scan based on provided parameters.
 
@@ -301,6 +300,8 @@ def get_plan(
     fast_grid_scan_composite.eiger.set_detector_parameters(
         parameters.artemis_params.detector_params
     )
+
+    subscriptions = FGSCallbackCollection.from_params(parameters)
 
     @bpp.subs_decorator(  # subscribe the RE to nexus, ispyb, and zocalo callbacks
         list(subscriptions)  # must be the outermost decorator to receive the metadata
@@ -341,4 +342,4 @@ if __name__ == "__main__":
 
     create_devices()
 
-    RE(get_plan(parameters, subscriptions))
+    RE(get_plan(parameters))

--- a/src/artemis/experiment_plans/full_grid_scan.py
+++ b/src/artemis/experiment_plans/full_grid_scan.py
@@ -62,7 +62,6 @@ def wait_for_det_to_finish_moving(detector: DetectorMotion, timeout=120):
 
 def get_plan(
     parameters: GridScanWithEdgeDetectInternalParameters,
-    subscriptions: FGSCallbackCollection,
     oav_param_files: dict = OAV_CONFIG_FILE_DEFAULTS,
 ) -> Callable:
     """

--- a/src/artemis/experiment_plans/rotation_scan_plan.py
+++ b/src/artemis/experiment_plans/rotation_scan_plan.py
@@ -22,15 +22,15 @@ from artemis.device_setup_plans.setup_zebra import (
     disarm_zebra,
     setup_zebra_for_rotation,
 )
+from artemis.external_interaction.callbacks.rotation.rotation_callback_collection import (
+    RotationCallbackCollection,
+)
 from artemis.log import LOGGER
 from artemis.parameters.plan_specific.rotation_scan_internal_params import (
     RotationScanParams,
 )
 
 if TYPE_CHECKING:
-    from artemis.external_interaction.callbacks.rotation.rotation_callback_collection import (
-        RotationCallbackCollection,
-    )
     from artemis.parameters.plan_specific.rotation_scan_internal_params import (
         RotationInternalParameters,
     )
@@ -154,9 +154,7 @@ def cleanup_plan(eiger, zebra, smargon, detector_motion, backlight):
     yield from finalize_wrapper(disarm_zebra(zebra), bps.wait("cleanup_senv"))
 
 
-def get_plan(
-    params: RotationInternalParameters, subscriptions: RotationCallbackCollection
-):
+def get_plan(params: RotationInternalParameters):
     eiger = i03.eiger(wait_for_connection=False)
     smargon = i03.smargon()
     zebra = i03.zebra()
@@ -169,6 +167,7 @@ def get_plan(
         "detector_motion": detector_motion,
         "backlight": backlight,
     }
+    subscriptions = RotationCallbackCollection.from_params(params)
 
     @subs_decorator(list(subscriptions))
     def rotation_scan_plan_with_stage_and_cleanup(

--- a/src/artemis/experiment_plans/tests/test_fast_grid_scan_plan.py
+++ b/src/artemis/experiment_plans/tests/test_fast_grid_scan_plan.py
@@ -23,6 +23,9 @@ from artemis.experiment_plans.fast_grid_scan_plan import (
     run_gridscan_and_move,
     wait_for_fgs_valid,
 )
+from artemis.external_interaction.callbacks.abstract_plan_callback_collection import (
+    AbstractPlanCallbackCollection,
+)
 from artemis.external_interaction.callbacks.fgs.fgs_callback_collection import (
     FGSCallbackCollection,
 )
@@ -318,8 +321,11 @@ def test_when_grid_scan_ran_then_eiger_disarmed_before_zocalo_end(
     with patch(
         "artemis.experiment_plans.fast_grid_scan_plan.fast_grid_scan_composite",
         fake_fgs_composite,
+    ), patch(
+        "artemis.experiment_plans.fast_grid_scan_plan.FGSCallbackCollection.from_params",
+        lambda _: mock_subscriptions,
     ):
-        RE(get_plan(test_fgs_params, mock_subscriptions))
+        RE(get_plan(test_fgs_params))
 
     mock_parent.assert_has_calls([call.disarm(), call.run_end(0), call.run_end(0)])
 

--- a/src/artemis/experiment_plans/tests/test_fast_grid_scan_plan.py
+++ b/src/artemis/experiment_plans/tests/test_fast_grid_scan_plan.py
@@ -23,9 +23,6 @@ from artemis.experiment_plans.fast_grid_scan_plan import (
     run_gridscan_and_move,
     wait_for_fgs_valid,
 )
-from artemis.external_interaction.callbacks.abstract_plan_callback_collection import (
-    AbstractPlanCallbackCollection,
-)
 from artemis.external_interaction.callbacks.fgs.fgs_callback_collection import (
     FGSCallbackCollection,
 )

--- a/src/artemis/experiment_plans/tests/test_full_grid_scan_plan.py
+++ b/src/artemis/experiment_plans/tests/test_full_grid_scan_plan.py
@@ -43,8 +43,11 @@ def test_wait_for_detector(RE):
     RE(wait_for_det_to_finish_moving(d_m, 0.5))
 
 
-def test_get_plan(test_params, mock_subscriptions, test_config_files):
-    with patch("artemis.experiment_plans.full_grid_scan.i03"):
-        plan = get_plan(test_params, mock_subscriptions, test_config_files)
+def test_get_plan(test_params, test_config_files, mock_subscriptions):
+    with patch("artemis.experiment_plans.full_grid_scan.i03"), patch(
+        "artemis.experiment_plans.fast_grid_scan_plan.FGSCallbackCollection.from_params",
+        lambda _: mock_subscriptions,
+    ):
+        plan = get_plan(test_params, test_config_files)
 
     assert isinstance(plan, Generator)

--- a/src/artemis/system_tests/test_main_system.py
+++ b/src/artemis/system_tests/test_main_system.py
@@ -29,7 +29,7 @@ Every test in this file which uses the test_env fixture should either:
     - set RE_takes_time to false
     or
     - set an error on the mock run engine
-In order to avoid threads which get left alive forever after test completion    
+In order to avoid threads which get left alive forever after test completion
 """
 
 

--- a/src/artemis/system_tests/test_main_system.py
+++ b/src/artemis/system_tests/test_main_system.py
@@ -13,9 +13,6 @@ from flask.testing import FlaskClient
 
 from artemis.__main__ import Actions, BlueskyRunner, Status, cli_arg_parse, create_app
 from artemis.experiment_plans.experiment_registry import PLAN_REGISTRY
-from artemis.external_interaction.callbacks.abstract_plan_callback_collection import (
-    AbstractPlanCallbackCollection,
-)
 from artemis.parameters import external_parameters
 from artemis.parameters.plan_specific.fgs_internal_params import FGSInternalParameters
 
@@ -94,6 +91,7 @@ def test_env():
         dict({k: mock_dict_values(v) for k, v in PLAN_REGISTRY.items()}, **TEST_EXPTS),
     ):
         app, runner = create_app({"TESTING": True}, mock_run_engine)
+
     runner_thread = threading.Thread(target=runner.wait_on_queue)
     runner_thread.start()
     with app.test_client() as client:
@@ -106,7 +104,10 @@ def test_env():
             yield ClientAndRunEngine(client, mock_run_engine)
 
     runner.shutdown()
-    runner_thread.join()
+    try:
+        runner_thread.join(timeout=3)
+    except Exception:
+        raise ("couldn't join")
 
 
 def wait_for_run_engine_status(
@@ -352,31 +353,6 @@ def test_when_blueskyrunner_initiated_and_skip_flag_is_set_then_setup_called_upo
         mock_setup.assert_not_called()
         runner.start(MagicMock(), MagicMock(), "fast_grid_scan")
         mock_setup.assert_called_once()
-
-
-@patch("artemis.experiment_plans.fast_grid_scan_plan.EigerDetector")
-@patch("artemis.experiment_plans.fast_grid_scan_plan.FGSComposite")
-@patch("artemis.experiment_plans.fast_grid_scan_plan.get_beamline_parameters")
-def test_when_plan_started_then_callbacks_created(
-    mock_get_beamline_params, mock_fgs, mock_eiger
-):
-    mock_callback: AbstractPlanCallbackCollection = MagicMock(
-        spec=AbstractPlanCallbackCollection
-    )
-    with patch.dict(
-        "artemis.__main__.PLAN_REGISTRY",
-        {
-            "fast_grid_scan": {
-                "setup": MagicMock(),
-                "run": MagicMock(),
-                "param_type": MagicMock(),
-                "callback_collection_type": mock_callback,
-            },
-        },
-    ):
-        runner = BlueskyRunner(MagicMock(), skip_startup_connection=True)
-        runner.start(MagicMock(), MagicMock(), "fast_grid_scan")
-        mock_callback.from_params.assert_called_once()
 
 
 @patch("artemis.experiment_plans.fast_grid_scan_plan.EigerDetector")

--- a/src/artemis/system_tests/test_main_system.py
+++ b/src/artemis/system_tests/test_main_system.py
@@ -221,6 +221,8 @@ def test_given_started_when_stopped_and_started_again_then_runs(
 def test_given_started_when_RE_stops_on_its_own_with_error_then_error_reported(
     test_env: ClientAndRunEngine,
 ):
+    test_env.mock_run_engine.aborting_takes_time = True
+
     test_env.client.put(START_ENDPOINT, data=TEST_PARAMS)
     error_message = "D'Oh"
     test_env.mock_run_engine.error = error_message
@@ -254,6 +256,8 @@ def test_given_started_when_RE_stops_on_its_own_happily_then_no_error_reported(
 
 
 def test_start_with_json_file_gives_success(test_env: ClientAndRunEngine):
+    test_env.mock_run_engine.RE_takes_time = False
+
     with open("test_parameters.json") as test_parameters_file:
         test_parameters_json = test_parameters_file.read()
     response = test_env.client.put(START_ENDPOINT, data=test_parameters_json)
@@ -399,6 +403,7 @@ def test_when_blueskyrunner_initiated_and_skip_flag_is_not_set_then_all_plans_se
 
 
 def test_log_on_invalid_json_params(caplog, test_env: ClientAndRunEngine):
+    test_env.mock_run_engine.RE_takes_time = False
     response = test_env.client.put(TEST_BAD_PARAM_ENDPOINT, data='{"bad":1}').json
     assert isinstance(response, dict)
     assert response.get("status") == Status.FAILED.value

--- a/src/artemis/system_tests/test_main_system.py
+++ b/src/artemis/system_tests/test_main_system.py
@@ -39,10 +39,16 @@ class MockRunEngine:
     error: Optional[str] = None
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:
+        time = 0.0
         while self.RE_takes_time:
             sleep(0.1)
+            time += 0.1
             if self.error:
                 raise Exception(self.error)
+            if time > 15:
+                raise TimeoutError(
+                    "Mock RunEngine thread spun too long without an error."
+                )
 
     def abort(self):
         while self.aborting_takes_time:

--- a/src/artemis/system_tests/test_main_system.py
+++ b/src/artemis/system_tests/test_main_system.py
@@ -24,6 +24,14 @@ SHUTDOWN_ENDPOINT = Actions.SHUTDOWN.value
 TEST_BAD_PARAM_ENDPOINT = "/fgs_real_params/" + Actions.START.value
 TEST_PARAMS = json.dumps(external_parameters.from_file("test_parameter_defaults.json"))
 
+"""
+Every test in this file which uses the test_env fixture should either:
+    - set RE_takes_time to false
+    or
+    - set an error on the mock run engine
+In order to avoid threads which get left alive forever after test completion    
+"""
+
 
 class MockRunEngine:
     RE_takes_time = True


### PR DESCRIPTION
Fixes #656

Moves the creation of callback objects into the respective experiment plans, needed for future removal of `__main__.py` and more consistent between plans.

Coincidentally fixes some tests which shouldn't have worked.

### To test:
1. Run tests
