### PR TITLE
Remove defaults from ArtemisParameters

### DIFF
--- a/src/artemis/parameters/constants.py
+++ b/src/artemis/parameters/constants.py
@@ -4,7 +4,6 @@ SIM_BEAMLINE = "BL03S"
 SIM_INSERTION_PREFIX = "SR03S"
 ISPYB_PLAN_NAME = "ispyb_readings"
 SIM_ZOCALO_ENV = "dev_artemis"
-DEFAULT_EXPERIMENT_TYPE = "grid_scan"
 BEAMLINE_PARAMETER_PATHS = {
     "i03": "/dls_sw/i03/software/daq_configuration/domain/beamlineParameters",
     "s03": "src/artemis/parameters/tests/test_data/test_beamline_parameters.txt",
@@ -13,21 +12,6 @@ BEAMLINE_PARAMETER_PATHS = {
 PARAMETER_VERSION = 0.2
 SIM_ISPYB_CONFIG = "src/artemis/external_interaction/unit_tests/test_config.cfg"
 PARAMETER_SCHEMA_DIRECTORY = "src/artemis/parameters/schemas/"
-
-DETECTOR_PARAM_DEFAULTS = {
-    "current_energy": 100,
-    "exposure_time": 0.1,
-    "directory": "/tmp",
-    "prefix": "file_name",
-    "run_number": 0,
-    "detector_distance": 100.0,
-    "omega_start": 0.0,
-    "omega_increment": 0.0,
-    "num_images_per_trigger": 1,
-    "num_triggers": 2000,
-    "use_roi_mode": False,
-    "det_dist_to_beam_converter_path": "src/artemis/unit_tests/test_lookup_table.txt",
-}
 
 
 class Actions(Enum):

--- a/src/artemis/parameters/internal_parameters.py
+++ b/src/artemis/parameters/internal_parameters.py
@@ -6,17 +6,7 @@ from dodal.parameters.experiment_parameter_base import AbstractExperimentParamet
 from pydantic import BaseModel, root_validator
 from semver import Version
 
-from artemis.external_interaction.ispyb.ispyb_dataclass import (
-    ISPYB_PARAM_DEFAULTS,
-    IspybParams,
-)
-from artemis.parameters.constants import (
-    DEFAULT_EXPERIMENT_TYPE,
-    DETECTOR_PARAM_DEFAULTS,
-    SIM_BEAMLINE,
-    SIM_INSERTION_PREFIX,
-    SIM_ZOCALO_ENV,
-)
+from artemis.external_interaction.ispyb.ispyb_dataclass import IspybParams
 from artemis.parameters.external_parameters import from_json
 
 
@@ -37,12 +27,12 @@ class ParameterVersion(Version):
 
 
 class ArtemisParameters(BaseModel):
-    zocalo_environment: str = SIM_ZOCALO_ENV
-    beamline: str = SIM_BEAMLINE
-    insertion_prefix: str = SIM_INSERTION_PREFIX
-    experiment_type: str = DEFAULT_EXPERIMENT_TYPE
-    detector_params: DetectorParams = DetectorParams(**DETECTOR_PARAM_DEFAULTS)
-    ispyb_params: IspybParams = IspybParams(**ISPYB_PARAM_DEFAULTS)
+    zocalo_environment: str
+    beamline: str
+    insertion_prefix: str
+    experiment_type: str
+    detector_params: DetectorParams
+    ispyb_params: IspybParams
 
     class Config:
         arbitrary_types_allowed = True

--- a/src/artemis/parameters/tests/test_data/bad_test_parameters_wrong_version.json
+++ b/src/artemis/parameters/tests/test_data/bad_test_parameters_wrong_version.json
@@ -2,6 +2,7 @@
     "params_version": "0.0.4",
     "artemis_params": {
         "beamline": "BL03S",
+        "insertion_prefix": "SR03S",
         "detector": "EIGER2_X_16M",
         "zocalo_environment": "devrmq",
         "experiment_type": "grid_scan",

--- a/src/artemis/parameters/tests/test_data/good_test_grid_with_edge_detect_parameters.json
+++ b/src/artemis/parameters/tests/test_data/good_test_grid_with_edge_detect_parameters.json
@@ -2,6 +2,7 @@
     "params_version": "1.0.0",
     "artemis_params": {
         "beamline": "BL03S",
+        "insertion_prefix": "SR03S",
         "detector": "EIGER2_X_16M",
         "zocalo_environment": "devrmq",
         "experiment_type": "full_grid_scan",

--- a/src/artemis/parameters/tests/test_data/good_test_parameters.json
+++ b/src/artemis/parameters/tests/test_data/good_test_parameters.json
@@ -2,6 +2,7 @@
     "params_version": "1.0.0",
     "artemis_params": {
         "beamline": "BL03S",
+        "insertion_prefix": "SR03S",
         "detector": "EIGER2_X_16M",
         "zocalo_environment": "devrmq",
         "experiment_type": "fast_grid_scan",

--- a/src/artemis/parameters/tests/test_data/good_test_rotation_scan_parameters.json
+++ b/src/artemis/parameters/tests/test_data/good_test_rotation_scan_parameters.json
@@ -2,6 +2,7 @@
     "params_version": "1.0.0",
     "artemis_params": {
         "beamline": "BL03S",
+        "insertion_prefix": "SR03S",
         "detector": "EIGER2_X_16M",
         "zocalo_environment": "dev_artemis",
         "experiment_type": "rotation_scan",

--- a/test_parameters.json
+++ b/test_parameters.json
@@ -2,6 +2,7 @@
     "params_version": "1.0.0",
     "artemis_params": {
         "beamline": "BL03S",
+        "insertion_prefix": "SR03S",
         "detector": "EIGER2_X_16M",
         "zocalo_environment": "devrmq",
         "experiment_type": "fast_grid_scan",


### PR DESCRIPTION
Fixes #741 

### To test:
1. On main, in a directory that is not the top level `python-artemis` one, start an interpreter and run `from artemis.parameters.internal_parameters import ArtemisParameters`, confirm it fails
2. Do the same on this branch, confirm it passes
