### PR TITLE
Apply flatfield by default when changing zoom level

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     xarray
     doct
     databroker
-    dodal @ git+https://github.com/DiamondLightSource/python-dodal.git@5cb5579b3eb29bdba8d5bf966ec965ed3aeba873
+    dodal @ git+https://github.com/DiamondLightSource/python-dodal.git@64f4a6cf3c2ed59dcd03fdc9ded1fc8d02f5cde7
 
 [options.extras_require]
 dev =

--- a/src/artemis/device_setup_plans/setup_oav.py
+++ b/src/artemis/device_setup_plans/setup_oav.py
@@ -88,13 +88,13 @@ def pre_centring_setup_oav(oav: OAV, parameters: OAVParameters):
     )
 
     zoom_level_str = f"{float(parameters.zoom)}x"
-    if zoom_level_str not in oav.zoom_controller.allowed_zoom_levels:
+    if zoom_level_str not in oav.zoom.allowed_zoom_levels:
         raise OAVError_ZoomLevelNotFound(
-            f"Found {zoom_level_str} as a zoom level but expected one of {oav.zoom_controller.allowed_zoom_levels}"
+            f"Found {zoom_level_str} as a zoom level but expected one of {oav.zoom.allowed_zoom_levels}"
         )
 
     yield from bps.abs_set(
-        oav.zoom_controller.level,
+        oav.zoom.level,
         zoom_level_str,
         wait=True,
     )

--- a/src/artemis/device_setup_plans/setup_oav.py
+++ b/src/artemis/device_setup_plans/setup_oav.py
@@ -87,8 +87,6 @@ def pre_centring_setup_oav(oav: OAV, parameters: OAVParameters):
         parameters.detection_script_filename,
     )
 
-    yield from bps.abs_set(oav.snapshot.input_plugin, parameters.input_plugin + ".CAM")
-
     zoom_level_str = f"{float(parameters.zoom)}x"
     if zoom_level_str not in oav.zoom_controller.allowed_zoom_levels:
         raise OAVError_ZoomLevelNotFound(

--- a/src/artemis/device_setup_plans/setup_oav.py
+++ b/src/artemis/device_setup_plans/setup_oav.py
@@ -7,18 +7,15 @@ from dodal.devices.oav.utils import ColorMode, EdgeOutputArrayImageType
 from artemis.log import LOGGER
 
 
-def start_mxsc(oav: OAV, input_plugin, min_callback_time, filename):
+def start_mxsc(oav: OAV, min_callback_time, filename):
     """
     Sets PVs relevant to edge detection plugin.
 
     Args:
-        input_plugin: link to the camera stream
         min_callback_time: the value to set the minimum callback time to
         filename: filename of the python script to detect edge waveforms from camera stream.
     Returns: None
     """
-    yield from bps.abs_set(oav.mxsc.input_plugin, input_plugin)
-
     # Turns the area detector plugin on
     yield from bps.abs_set(oav.mxsc.enable_callbacks, 1)
 
@@ -82,7 +79,6 @@ def pre_centring_setup_oav(oav: OAV, parameters: OAVParameters):
     # Connect MXSC output to MJPG input
     yield from start_mxsc(
         oav,
-        parameters.input_plugin + "." + parameters.mxsc_input,
         parameters.min_callback_time,
         parameters.detection_script_filename,
     )

--- a/src/artemis/experiment_plans/oav_grid_detection_plan.py
+++ b/src/artemis/experiment_plans/oav_grid_detection_plan.py
@@ -45,7 +45,7 @@ def grid_detection_plan(
             width,
             box_size_microns,
         ),
-        reset_oav(parameters),
+        reset_oav(),
     )
 
 
@@ -207,6 +207,6 @@ def grid_detection_main_plan(
     out_parameters.z_step_size = box_size_um / 1000
 
 
-def reset_oav(parameters: OAVParameters):
+def reset_oav():
     oav = i03.oav()
     yield from bps.abs_set(oav.mxsc.enable_callbacks, 0)

--- a/src/artemis/experiment_plans/oav_grid_detection_plan.py
+++ b/src/artemis/experiment_plans/oav_grid_detection_plan.py
@@ -209,5 +209,4 @@ def grid_detection_main_plan(
 
 def reset_oav(parameters: OAVParameters):
     oav = i03.oav()
-    yield from bps.abs_set(oav.snapshot.input_plugin, parameters.input_plugin + ".CAM")
     yield from bps.abs_set(oav.mxsc.enable_callbacks, 0)

--- a/src/artemis/experiment_plans/tests/test_grid_detection_plan.py
+++ b/src/artemis/experiment_plans/tests/test_grid_detection_plan.py
@@ -27,12 +27,12 @@ def fake_create_devices():
     bl = i03.backlight(fake_with_ophyd_sim=True)
     bl.wait_for_connection()
 
-    oav.zoom_controller.zrst.set("1.0x")
-    oav.zoom_controller.onst.set("2.0x")
-    oav.zoom_controller.twst.set("3.0x")
-    oav.zoom_controller.thst.set("5.0x")
-    oav.zoom_controller.frst.set("7.0x")
-    oav.zoom_controller.fvst.set("9.0x")
+    oav.zoom.zrst.set("1.0x")
+    oav.zoom.onst.set("2.0x")
+    oav.zoom.twst.set("3.0x")
+    oav.zoom.thst.set("5.0x")
+    oav.zoom.frst.set("7.0x")
+    oav.zoom.fvst.set("9.0x")
 
     # fmt: off
     oav.mxsc.bottom.set([0,0,0,0,0,0,0,0,1,1,1,1,1,2,2,2,2,3,3,3,3,33,3,4,4,4])  # noqa: E231


### PR DESCRIPTION
Fixes https://github.com/DiamondLightSource/dodal/issues/103

This mainly just removes the need for Artemis to set the plugins for the OAV as this is handled inside the device when zoom level is changed

Link to dodal PR (if required): https://github.com/DiamondLightSource/dodal/pull/104

### To test:
1. Confirm tests still pass
