### PR TITLE
Fix transmission rename for rotation scans

### DIFF
--- a/live_test_rotation_params.json
+++ b/live_test_rotation_params.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "2.0.0",
+    "params_version": "2.1.0",
     "artemis_params": {
         "beamline": "BL03I",
         "insertion_prefix": "SR03I",
@@ -43,7 +43,7 @@
                 "test_2",
                 "test_3"
             ],
-            "transmission": 1.0,
+            "transmission_fraction": 1.0,
             "flux": 10.0,
             "wavelength": 0.01,
             "beam_size_x": 1.0,

--- a/live_test_rotation_params_move_xyz.json
+++ b/live_test_rotation_params_move_xyz.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "2.0.0",
+    "params_version": "2.1.0",
     "artemis_params": {
         "beamline": "BL03I",
         "insertion_prefix": "SR03I",
@@ -43,7 +43,7 @@
                 "test_2",
                 "test_3"
             ],
-            "transmission": 1.0,
+            "transmission_fraction": 1.0,
             "flux": 10.0,
             "wavelength": 0.01,
             "beam_size_x": 1.0,

--- a/src/artemis/experiment_plans/rotation_scan_plan.py
+++ b/src/artemis/experiment_plans/rotation_scan_plan.py
@@ -196,7 +196,7 @@ def rotation_scan_plan(
         f" for {shutter_time_s} s at {speed_for_rotation_deg_s} deg/s"
     )
 
-    transmission = params.artemis_params.ispyb_params.transmission
+    transmission = params.artemis_params.ispyb_params.transmission_fraction
     yield from setup_sample_environment(
         detector_motion, backlight, attenuator, transmission
     )

--- a/src/artemis/external_interaction/ispyb/ispyb_dataclass.py
+++ b/src/artemis/external_interaction/ispyb/ispyb_dataclass.py
@@ -77,7 +77,7 @@ class IspybParams(BaseModel):
     xtal_snapshots_omega_end: Optional[List[str]] = None
 
     @validator("transmission_fraction")
-    def transmission_not_percentage(cls, transmission_fraction: float):
+    def _transmission_not_percentage(cls, transmission_fraction: float):
         if transmission_fraction > 1:
             raise ValueError(
                 "Transmission_fraction of >1 given. Did you give a percentage instead of a fraction?"

--- a/src/artemis/parameters/tests/test_data/good_test_rotation_scan_parameters_nomove.json
+++ b/src/artemis/parameters/tests/test_data/good_test_rotation_scan_parameters_nomove.json
@@ -1,5 +1,5 @@
 {
-    "params_version": "2.0.0",
+    "params_version": "2.1.0",
     "artemis_params": {
         "beamline": "BL03S",
         "insertion_prefix": "SR03S",
@@ -43,7 +43,7 @@
                 "test_2",
                 "test_3"
             ],
-            "transmission": 1.0,
+            "transmission_fraction": 1.0,
             "flux": 10.0,
             "wavelength": 0.01,
             "beam_size_x": 1.0,


### PR DESCRIPTION
Fixes #847

Also changed the name of the validator to avoid confusion around how to get the variable out.

### To test:
1. Confirm tests pass now
