### PR TITLE
Fix rotation plan tests

### DIFF
--- a/src/artemis/experiment_plans/tests/test_rotation_scan_plan.py
+++ b/src/artemis/experiment_plans/tests/test_rotation_scan_plan.py
@@ -455,9 +455,6 @@ def test_cleanup_happens(
                 test_rotation_params,
                 smargon,
                 zebra,
-                backlight,
-                attenuator,
-                detector_motion,
             )
         )
         cleanup_plan.assert_not_called()


### PR DESCRIPTION
### To test:
1. Confirm that unit tests now pass
