### PR TITLE
(#891) Renamed plans to reflect more closely what they do

### DIFF
--- a/src/hyperion/device_setup_plans/read_hardware_for_setup.py
+++ b/src/hyperion/device_setup_plans/read_hardware_for_setup.py
@@ -5,8 +5,8 @@ from dodal.beamlines.i03 import Attenuator, Flux, S4SlitGaps, Synchrotron, Undul
 
 import hyperion.log
 from hyperion.parameters.constants import (
-    ISPYB_PLAN_NAME,
-    ISPYB_UPDATING_COLLECTION,
+    ISPYB_HARDWARE_READ_PLAN,
+    ISPYB_TRANSMISSION_FLUX_READ_PLAN,
 )
 
 
@@ -19,7 +19,7 @@ def read_hardware_for_ispyb_pre_collection(
         "Reading status of beamline parameters for ispyb deposition."
     )
     yield from bps.create(
-        name=ISPYB_PLAN_NAME
+        name=ISPYB_HARDWARE_READ_PLAN
     )  # gives name to event *descriptor* document
     yield from bps.read(undulator.gap)
     yield from bps.read(synchrotron.machine_status.synchrotron_mode)
@@ -32,7 +32,7 @@ def read_hardware_for_ispyb_during_collection(attenuator: Attenuator, flux: Flux
     hyperion.log.LOGGER.info(
         "Reading status of beamline parameters for ispyb deposition."
     )
-    yield from bps.create(name=ISPYB_UPDATING_COLLECTION)
+    yield from bps.create(name=ISPYB_TRANSMISSION_FLUX_READ_PLAN)
     yield from bps.read(attenuator.actual_transmission)
     yield from bps.read(flux.flux_reading)
     yield from bps.save()

--- a/src/hyperion/experiment_plans/tests/test_flyscan_xray_centre_plan.py
+++ b/src/hyperion/experiment_plans/tests/test_flyscan_xray_centre_plan.py
@@ -44,7 +44,10 @@ from hyperion.external_interaction.system_tests.conftest import (
 )
 from hyperion.log import set_up_logging_handlers
 from hyperion.parameters import external_parameters
-from hyperion.parameters.constants import ISPYB_PLAN_NAME, ISPYB_UPDATING_COLLECTION
+from hyperion.parameters.constants import (
+    ISPYB_HARDWARE_READ_PLAN,
+    ISPYB_TRANSMISSION_FLUX_READ_PLAN,
+)
 from hyperion.parameters.plan_specific.gridscan_internal_params import (
     GridscanInternalParameters,
 )
@@ -149,7 +152,7 @@ def test_results_adjusted_and_passed_to_move_xyz(
     RE.subscribe(VerbosePlanExecutionLoggingCallback())
 
     mock_subscriptions.ispyb_handler.descriptor(
-        {"uid": "123abc", "name": ISPYB_PLAN_NAME}
+        {"uid": "123abc", "name": ISPYB_HARDWARE_READ_PLAN}
     )
     mock_subscriptions.ispyb_handler.event(
         {
@@ -163,7 +166,7 @@ def test_results_adjusted_and_passed_to_move_xyz(
         }
     )
     mock_subscriptions.ispyb_handler.descriptor(
-        {"uid": "abc123", "name": ISPYB_UPDATING_COLLECTION}
+        {"uid": "abc123", "name": ISPYB_TRANSMISSION_FLUX_READ_PLAN}
     )
     mock_subscriptions.ispyb_handler.event(
         {
@@ -282,7 +285,7 @@ def test_individual_plans_triggered_once_and_only_once_in_composite_run(
     RE: RunEngine,
 ):
     mock_subscriptions.ispyb_handler.descriptor(
-        {"uid": "123abc", "name": ISPYB_PLAN_NAME}
+        {"uid": "123abc", "name": ISPYB_HARDWARE_READ_PLAN}
     )
 
     mock_subscriptions.ispyb_handler.event(
@@ -297,7 +300,7 @@ def test_individual_plans_triggered_once_and_only_once_in_composite_run(
         }
     )
     mock_subscriptions.ispyb_handler.descriptor(
-        {"uid": "abc123", "name": ISPYB_UPDATING_COLLECTION}
+        {"uid": "abc123", "name": ISPYB_TRANSMISSION_FLUX_READ_PLAN}
     )
     mock_subscriptions.ispyb_handler.event(
         {
@@ -344,7 +347,7 @@ def test_logging_within_plan(
     RE: RunEngine,
 ):
     mock_subscriptions.ispyb_handler.descriptor(
-        {"uid": "123abc", "name": ISPYB_PLAN_NAME}
+        {"uid": "123abc", "name": ISPYB_HARDWARE_READ_PLAN}
     )
 
     mock_subscriptions.ispyb_handler.event(
@@ -359,7 +362,7 @@ def test_logging_within_plan(
         }
     )
     mock_subscriptions.ispyb_handler.descriptor(
-        {"uid": "abc123", "name": ISPYB_UPDATING_COLLECTION}
+        {"uid": "abc123", "name": ISPYB_TRANSMISSION_FLUX_READ_PLAN}
     )
     mock_subscriptions.ispyb_handler.event(
         {

--- a/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
+++ b/src/hyperion/external_interaction/callbacks/ispyb_callback_base.py
@@ -8,8 +8,8 @@ from bluesky.callbacks import CallbackBase
 from hyperion.external_interaction.ispyb.store_in_ispyb import StoreInIspyb
 from hyperion.log import LOGGER, set_dcgid_tag
 from hyperion.parameters.constants import (
-    ISPYB_PLAN_NAME,
-    ISPYB_UPDATING_COLLECTION,
+    ISPYB_HARDWARE_READ_PLAN,
+    ISPYB_TRANSMISSION_FLUX_READ_PLAN,
     SIM_ISPYB_CONFIG,
 )
 from hyperion.parameters.plan_specific.gridscan_internal_params import (
@@ -56,7 +56,7 @@ class BaseISPyBCallback(CallbackBase):
         ), "ISPyB deposition can't be initialised!"
         event_descriptor = self.descriptors[doc["descriptor"]]
 
-        if event_descriptor.get("name") == ISPYB_PLAN_NAME:
+        if event_descriptor.get("name") == ISPYB_HARDWARE_READ_PLAN:
             self.params.hyperion_params.ispyb_params.undulator_gap = doc["data"][
                 "undulator_gap"
             ]
@@ -70,7 +70,7 @@ class BaseISPyBCallback(CallbackBase):
                 "s4_slit_gaps_ygap"
             ]
 
-        if event_descriptor.get("name") == ISPYB_UPDATING_COLLECTION:
+        if event_descriptor.get("name") == ISPYB_TRANSMISSION_FLUX_READ_PLAN:
             self.params.hyperion_params.ispyb_params.transmission_fraction = doc[
                 "data"
             ]["attenuator_actual_transmission"]

--- a/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
+++ b/src/hyperion/external_interaction/callbacks/rotation/ispyb_callback.py
@@ -13,7 +13,7 @@ from hyperion.parameters.plan_specific.gridscan_internal_params import (
 class RotationISPyBCallback(BaseISPyBCallback):
     """Callback class to handle the deposition of experiment parameters into the ISPyB
     database. Listens for 'event' and 'descriptor' documents. Creates the ISpyB entry on
-    recieving an 'event' document for the 'ispyb_readings' event, and updates the
+    recieving an 'event' document for the 'ispyb_reading_hardware' event, and updates the
     deposition on recieving its final 'stop' document.
 
     To use, subscribe the Bluesky RunEngine to an instance of this class.

--- a/src/hyperion/external_interaction/callbacks/xray_centre/ispyb_callback.py
+++ b/src/hyperion/external_interaction/callbacks/xray_centre/ispyb_callback.py
@@ -18,7 +18,7 @@ from hyperion.parameters.plan_specific.gridscan_internal_params import (
 class GridscanISPyBCallback(BaseISPyBCallback):
     """Callback class to handle the deposition of experiment parameters into the ISPyB
     database. Listens for 'event' and 'descriptor' documents. Creates the ISpyB entry on
-    recieving an 'event' document for the 'ispyb_readings' event, and updates the
+    recieving an 'event' document for the 'ispyb_reading_hardware' event, and updates the
     deposition on recieving its final 'stop' document.
 
     To use, subscribe the Bluesky RunEngine to an instance of this class.

--- a/src/hyperion/external_interaction/callbacks/xray_centre/nexus_callback.py
+++ b/src/hyperion/external_interaction/callbacks/xray_centre/nexus_callback.py
@@ -4,7 +4,7 @@ from bluesky.callbacks import CallbackBase
 
 from hyperion.external_interaction.nexus.write_nexus import NexusWriter
 from hyperion.log import LOGGER
-from hyperion.parameters.constants import ISPYB_PLAN_NAME
+from hyperion.parameters.constants import ISPYB_HARDWARE_READ_PLAN
 from hyperion.parameters.plan_specific.gridscan_internal_params import (
     GridscanInternalParameters,
 )
@@ -15,7 +15,7 @@ class GridscanNexusFileCallback(CallbackBase):
     parameters. Initialises on recieving a 'start' document for the \
     'run_gridscan_move_and_tidy' sub plan, which must also contain the run parameters, \
     as metadata under the 'hyperion_internal_parameters' key. Actually writes the \
-    nexus files on updates the timestamps on recieving the 'ispyb_readings' event \
+    nexus files on updates the timestamps on recieving the 'ispyb_reading_hardware' event \
     document, and finalises the files on getting a 'stop' document for the whole run.
 
     To use, subscribe the Bluesky RunEngine to an instance of this class.
@@ -45,7 +45,7 @@ class GridscanNexusFileCallback(CallbackBase):
             self.run_start_uid = doc.get("uid")
 
     def descriptor(self, doc):
-        if doc.get("name") == ISPYB_PLAN_NAME:
+        if doc.get("name") == ISPYB_HARDWARE_READ_PLAN:
             assert (
                 self.parameters is not None
             ), "Nexus callback did not receive parameters before being asked to write!"

--- a/src/hyperion/external_interaction/callbacks/xray_centre/tests/conftest.py
+++ b/src/hyperion/external_interaction/callbacks/xray_centre/tests/conftest.py
@@ -2,7 +2,10 @@ from unittest.mock import patch
 
 import pytest
 
-from hyperion.parameters.constants import ISPYB_PLAN_NAME, ISPYB_UPDATING_COLLECTION
+from hyperion.parameters.constants import (
+    ISPYB_HARDWARE_READ_PLAN,
+    ISPYB_TRANSMISSION_FLUX_READ_PLAN,
+)
 
 
 @pytest.fixture
@@ -86,12 +89,12 @@ class TestData:
     test_descriptor_document_pre_data_collection: dict = {
         "uid": "bd45c2e5-2b85-4280-95d7-a9a15800a78b",
         "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
-        "name": ISPYB_PLAN_NAME,
+        "name": ISPYB_HARDWARE_READ_PLAN,
     }
     test_descriptor_document_during_data_collection: dict = {
         "uid": "bd45c2e5-2b85-4280-95d7-a9a15800a78b",
         "run_start": "d8bee3ee-f614-4e7a-a516-25d6b9e87ef3",
-        "name": ISPYB_UPDATING_COLLECTION,
+        "name": ISPYB_TRANSMISSION_FLUX_READ_PLAN,
     }
     test_event_document_pre_data_collection: dict = {
         "descriptor": "bd45c2e5-2b85-4280-95d7-a9a15800a78b",

--- a/src/hyperion/external_interaction/callbacks/xray_centre/tests/test_nexus_handler.py
+++ b/src/hyperion/external_interaction/callbacks/xray_centre/tests/test_nexus_handler.py
@@ -5,7 +5,7 @@ import pytest
 from hyperion.external_interaction.callbacks.xray_centre.nexus_callback import (
     GridscanNexusFileCallback,
 )
-from hyperion.parameters.constants import ISPYB_PLAN_NAME
+from hyperion.parameters.constants import ISPYB_HARDWARE_READ_PLAN
 from hyperion.parameters.external_parameters import from_file as default_raw_params
 from hyperion.parameters.plan_specific.gridscan_internal_params import (
     GridscanInternalParameters,
@@ -72,7 +72,7 @@ def test_writers_dont_create_on_init_but_do_on_ispyb_event(
         "hyperion.external_interaction.callbacks.xray_centre.nexus_callback.NexusWriter",
         mock_writer,
     ):
-        nexus_handler.descriptor({"name": ISPYB_PLAN_NAME})
+        nexus_handler.descriptor({"name": ISPYB_HARDWARE_READ_PLAN})
 
     assert nexus_handler.nexus_writer_1 is not None
     assert nexus_handler.nexus_writer_2 is not None
@@ -102,7 +102,7 @@ def test_writers_do_create_one_file_each_on_start_doc_for_run_gridscan(
     ):
         nexus_handler.descriptor(
             {
-                "name": "ispyb_readings",
+                "name": "ispyb_reading_hardware",
             }
         )
 
@@ -117,7 +117,7 @@ def test_sensible_error_if_writing_triggered_before_params_received(
     with pytest.raises(AssertionError) as excinfo:
         nexus_handler.descriptor(
             {
-                "name": "ispyb_readings",
+                "name": "ispyb_reading_hardware",
             }
         )
 

--- a/src/hyperion/parameters/constants.py
+++ b/src/hyperion/parameters/constants.py
@@ -2,8 +2,8 @@ from enum import Enum
 
 SIM_BEAMLINE = "BL03S"
 SIM_INSERTION_PREFIX = "SR03S"
-ISPYB_PLAN_NAME = "ispyb_readings"
-ISPYB_UPDATING_COLLECTION = "ispyb_update_collection"
+ISPYB_HARDWARE_READ_PLAN = "ispyb_reading_hardware"
+ISPYB_TRANSMISSION_FLUX_READ_PLAN = "ispyb_update_transmission_flux"
 SIM_ZOCALO_ENV = "dev_artemis"
 BEAMLINE_PARAMETER_PATHS = {
     "i03": "/dls_sw/i03/software/daq_configuration/domain/beamlineParameters",


### PR DESCRIPTION
Fixes #891

Changed names of `ISPYB_PLAN_NAME `and  `ISPYB_UPDATING_COLLECTION `to `ISPYB_HARDWARE_READ_PLAN` and I`SPYB_TRANSMISSION_FLUX_READ_PLAN` respectively following suggesting from https://github.com/DiamondLightSource/hyperion/pull/937#discussion_r1368406664

### To test:
1. Confirm Tests
