### PR TITLE
Pin to version of blueapi with happy dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ package_dir =
 install_requires =
     bluesky
     pyepics
-    blueapi
+    blueapi @ git+https://github.com/DiamondLightSource/blueapi.git@5b8d60a9da8c1ab32300fef9e328100988cb2a43 # Needed until https://github.com/DiamondLightSource/blueapi/pull/456 is released
     flask-restful
     ispyb
     scanspec


### PR DESCRIPTION
Fixes DiamondLightSource/hyperion#1346

Link to dodal PR (if required): https://github.com/DiamondLightSource/dodal/pull/510

I tried to think of a way to test this but there's some oddness around the program calling itself, particularly if you try and call `run_hyperion.sh` then the first thing it does is kill any python programs mentioning `hyperion` i.e. the tests. I think this is such an edge case that it's fine. System tests also probably cover it

### To test:
1. On `main` run `hyperion` and confirm it fails with `stomp`/`starlette` errors
2. With the `dodal` change and this change run `./utility_scripts/dls_dev_env.sh`
3. Run `hyperion` and doesn't have the dependency issues
