### PR TITLE
Stage eiger asynchronously in rotation plan

### DIFF
--- a/src/hyperion/device_setup_plans/manipulate_sample.py
+++ b/src/hyperion/device_setup_plans/manipulate_sample.py
@@ -16,15 +16,11 @@ LOWER_DETECTOR_SHUTTER_AFTER_SCAN = True
 
 
 def begin_sample_environment_setup(
-    detector_motion: DetectorMotion,
     attenuator: Attenuator,
     transmission_fraction: float,
-    detector_distance: float,
     group="setup_senv",
 ):
     """Start all sample environment changes that can be initiated before OAV snapshots are taken"""
-    yield from bps.abs_set(detector_motion.shutter, 1, group=group)
-    yield from bps.abs_set(detector_motion.z, detector_distance, group=group)
     yield from bps.abs_set(attenuator, transmission_fraction, group=group)
 
 

--- a/src/hyperion/experiment_plans/rotation_scan_plan.py
+++ b/src/hyperion/experiment_plans/rotation_scan_plan.py
@@ -40,6 +40,9 @@ from hyperion.device_setup_plans.setup_zebra import (
     make_trigger_safe,
     setup_zebra_for_rotation,
 )
+from hyperion.device_setup_plans.utils import (
+    start_preparing_data_collection_then_do_plan,
+)
 from hyperion.experiment_plans.oav_snapshot_plan import (
     OavSnapshotComposite,
     oav_snapshot_plan,
@@ -199,8 +202,7 @@ def rotation_scan_plan(
         yield from bps.abs_set(
             axis,
             motion_values.start_motion_deg,
-            group="move_to_rotation_start",
-            wait=True,
+            group=CONST.WAIT.ROTATION_READY_FOR_DC,
         )
 
         yield from setup_zebra_for_rotation(
@@ -211,19 +213,18 @@ def rotation_scan_plan(
             shutter_opening_deg=motion_values.shutter_opening_deg,
             shutter_opening_s=motion_values.shutter_time_s,
             group="setup_zebra",
-            wait=True,
         )
 
         yield from setup_sample_environment(
             composite.aperture_scatterguard,
             params.selected_aperture,
             composite.backlight,
+            group=CONST.WAIT.ROTATION_READY_FOR_DC,
         )
 
         LOGGER.info("Wait for any previous moves...")
         # wait for all the setup tasks at once
-        yield from bps.wait("setup_senv")
-        yield from bps.wait("move_to_rotation_start")
+        yield from bps.wait(CONST.WAIT.ROTATION_READY_FOR_DC)
 
         # get some information for the ispyb deposition and trigger the callback
         yield from read_hardware_for_zocalo(composite.eiger)
@@ -312,16 +313,14 @@ def rotation_scan(
         eiger: EigerDetector = composite.eiger
         eiger.set_detector_parameters(params.detector_params)
 
-        @bpp.stage_decorator([eiger])
         @bpp.finalize_decorator(lambda: cleanup_plan(composite, max_vel))
         def rotation_with_cleanup_and_stage(params: RotationScan):
             assert composite.aperture_scatterguard.aperture_positions is not None
             LOGGER.info("setting up sample environment...")
             yield from begin_sample_environment_setup(
-                composite.detector_motion,
                 composite.attenuator,
                 params.transmission_frac,
-                params.detector_params.detector_distance,
+                group=CONST.WAIT.ROTATION_READY_FOR_DC,
             )
             LOGGER.info("moving to position (if specified)")
             yield from move_x_y_z(
@@ -348,6 +347,13 @@ def rotation_scan(
             yield from rotation_scan_plan(composite, params, motion_values)
 
         LOGGER.info("setting up and staging eiger...")
-        yield from rotation_with_cleanup_and_stage(params)
+        yield from start_preparing_data_collection_then_do_plan(
+            eiger,
+            composite.detector_motion,
+            params.detector_distance_mm,
+            rotation_with_cleanup_and_stage(params),
+            group=CONST.WAIT.ROTATION_READY_FOR_DC,
+        )
+        yield from bps.unstage(eiger)
 
     yield from rotation_scan_plan_with_stage_and_cleanup(parameters)

--- a/src/hyperion/parameters/constants.py
+++ b/src/hyperion/parameters/constants.py
@@ -37,8 +37,8 @@ class PlanNameConstants:
 @dataclass(frozen=True)
 class PlanGroupCheckpointConstants:
     # For places to synchronise / stop and wait in plans, use as bluesky group names
-    # Gridscan
-    GRID_READY_FOR_DC = "ready_for_data_collection"
+    GRID_READY_FOR_DC = "grid_ready_for_data_collection"
+    ROTATION_READY_FOR_DC = "rotation_ready_for_data_collection"
 
 
 @dataclass(frozen=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,6 +263,7 @@ def done_status():
 def eiger(done_status):
     eiger = i03.eiger(fake_with_ophyd_sim=True)
     eiger.stage = MagicMock(return_value=done_status)
+    eiger.do_arm.set = MagicMock(return_value=done_status)
     eiger.unstage = MagicMock(return_value=done_status)
     return eiger
 

--- a/tests/unit_tests/experiment_plans/test_grid_detect_then_xray_centre_plan.py
+++ b/tests/unit_tests/experiment_plans/test_grid_detect_then_xray_centre_plan.py
@@ -183,7 +183,7 @@ def test_when_full_grid_scan_run_then_parameters_sent_to_fgs_as_expected(
 
     mock_grid_detection_plan.side_effect = _fake_grid_detection
 
-    with patch.object(eiger.do_arm, "set", MagicMock()), patch.object(
+    with patch.object(
         grid_detect_devices_with_oav_config_params.aperture_scatterguard,
         "set",
         MagicMock(),


### PR DESCRIPTION
Fixes DiamondLightSource/mx-bluesky#206

Makes use of the `start_preparing_data_collection_then_do_plan` plan stub we have for setting up the collection that we use in the XRC. `begin_sample_environment_setup` will ultimately be fully removed by https://github.com/DiamondLightSource/mx-bluesky/issues/205

### To test:
1. Confirm tests pass
2. Manually confirm `grid_detect_then_xray_centre_composite` still passes
